### PR TITLE
Update cache busting versions and old branch references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We value your input! We want to make contributing to this project as easy and tr
 
 ## We use GitHub [Pull Requests](https://github.com/BlazorRepl/BlazorRepl/pulls) for accepting code changes 
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. Be consistent with the existing code
 3. Make sure your code passes all code style analyzer checks.
 4. Write a detailed description of the changes you have made. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![MudBlazor](content/MudBlazor-GitHub-NoBg.png)
 # TryMudBlazor
-[![GitHub](https://img.shields.io/github/license/mudblazor/trymudblazor?color=594ae2&logo=github&style=flat-square)](https://github.com/MudBlazor/TryMudBlazor/blob/master/LICENSE)
+[![GitHub](https://img.shields.io/github/license/mudblazor/trymudblazor?color=594ae2&logo=github&style=flat-square)](https://github.com/MudBlazor/TryMudBlazor/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/786656789310865418?color=%237289da&label=Discord&logo=discord&logoColor=%237289da&style=flat-square)](https://discord.gg/mudblazor)
 [![Twitter](https://img.shields.io/twitter/follow/MudBlazor?color=1DA1F2&label=Twitter&logo=Twitter&style=flat-square)](https://twitter.com/MudBlazor)
 

--- a/src/TryMudBlazor.Client/Pages/Index/Index.razor
+++ b/src/TryMudBlazor.Client/Pages/Index/Index.razor
@@ -150,7 +150,7 @@
                     </ul>
                 </MudItem>
             </MudGrid>
-            <MudText Align="Align.Center" Typo="Typo.body2" Class="mb-8 mt-16"><MudLink Typo="Typo.body2" Href="https://github.com/MudBlazor/TryMudBlazor/blob/master/LICENSE" Target="_blank">GNU General Public License v2.0.</MudLink></MudText>
+            <MudText Align="Align.Center" Typo="Typo.body2" Class="mb-8 mt-16"><MudLink Typo="Typo.body2" Href="https://github.com/MudBlazor/TryMudBlazor/blob/main/LICENSE" Target="_blank">GNU General Public License v2.0.</MudLink></MudText>
         </MudContainer>
     </MudMainContent>
 </MudLayout>

--- a/src/TryMudBlazor.Client/wwwroot/index.html
+++ b/src/TryMudBlazor.Client/wwwroot/index.html
@@ -30,8 +30,8 @@
     <link href="https://fonts.googleapis.com/css?family=Poppins:300,400,500,600" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,300,400" rel="stylesheet">
 
-    <link href="_content/MudBlazor/MudBlazor.min.css?v=5.2.0" rel="stylesheet" />
-    <link href="css/TryMudBlazor.min.css?v=5.2.0" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css?v=6.0.2" rel="stylesheet" />
+    <link href="css/TryMudBlazor.min.css?v=6.0.2" rel="stylesheet" />
 
     <script src="lib/split.js/split.min.js"></script>
     <script src="lib/monaco-editor/min/vs/loader.js"></script>
@@ -62,8 +62,8 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/MudBlazor/MudBlazor.min.js?v=5.2.0"></script>
-    <script src="js/app.js?v=5.2.0"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js?v=6.0.2"></script>
+    <script src="js/app.js?v=6.0.2"></script>
 </body>
 
 </html>


### PR DESCRIPTION
I noticed that the versions should be v6.0.2 now to match the latest version of MudBlazor and also that there were references to the old master branch.  I have updated these references.