### PR TITLE
Attempt to fix loading of Try.UserComponents.dll

### DIFF
--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -208,9 +208,8 @@
 
             if (compilationResult?.AssemblyBytes?.Length > 0)
             {
-                this.UnmarshalledJsRuntime.InvokeUnmarshalled<byte[], object>(
-                    "App.Repl.updateUserAssemblyInCacheStorage",
-                    compilationResult.AssemblyBytes);
+                // Make sure the DLL is updated before reloading the user page
+                await this.JsRuntime.InvokeVoidAsync("App.CodeExecution.updateUserComponentsDll", compilationResult.AssemblyBytes);
 
                 // TODO: Add error page in iframe
                 this.JsRuntime.InvokeVoid("App.reloadIFrame", "user-page-window", MainUserPagePath);

--- a/src/TryMudBlazor.Client/Services/HandleCriticalUserComponentExceptionsLogger.cs
+++ b/src/TryMudBlazor.Client/Services/HandleCriticalUserComponentExceptionsLogger.cs
@@ -11,11 +11,11 @@
     // (Approach: https://github.com/dotnet/aspnetcore/issues/13452#issuecomment-632660280)
     public class HandleCriticalUserComponentExceptionsLogger : ILogger
     {
-        private readonly IJSUnmarshalledRuntime unmarshalledJsRuntime;
+        private readonly IJSInProcessRuntime _jsRuntime;
 
-        public HandleCriticalUserComponentExceptionsLogger(IJSUnmarshalledRuntime unmarshalledJsRuntime)
+        public HandleCriticalUserComponentExceptionsLogger(IJSInProcessRuntime jsRuntime)
         {
-            this.unmarshalledJsRuntime = unmarshalledJsRuntime;
+            _jsRuntime = jsRuntime;
         }
 
         public void Log<TState>(
@@ -27,9 +27,9 @@
         {
             if (exception?.ToString()?.Contains(CompilationService.DefaultRootNamespace) ?? false)
             {
-                this.unmarshalledJsRuntime.InvokeUnmarshalled<byte[], object>(
-                    "App.Repl.updateUserAssemblyInCacheStorage",
-                    Convert.FromBase64String(CoreConstants.DefaultUserComponentsAssemblyBytes));
+                _jsRuntime.InvokeVoid(
+                    "App.CodeExecution.updateUserComponentsDll",
+                    CoreConstants.DefaultUserComponentsAssemblyBytes);
             }
         }
 

--- a/src/TryMudBlazor.Client/Services/HandleCriticalUserComponentExceptionsLoggerProvider.cs
+++ b/src/TryMudBlazor.Client/Services/HandleCriticalUserComponentExceptionsLoggerProvider.cs
@@ -5,14 +5,14 @@
 
     public class HandleCriticalUserComponentExceptionsLoggerProvider : ILoggerProvider
     {
-        private readonly IJSUnmarshalledRuntime unmarshalledJsRuntime;
+        private readonly IJSInProcessRuntime _jsRuntime;
 
-        public HandleCriticalUserComponentExceptionsLoggerProvider(IJSUnmarshalledRuntime unmarshalledJsRuntime)
+        public HandleCriticalUserComponentExceptionsLoggerProvider(IJSInProcessRuntime jsRuntime)
         {
-            this.unmarshalledJsRuntime = unmarshalledJsRuntime;
+            _jsRuntime = jsRuntime;
         }
 
-        public ILogger CreateLogger(string categoryName) => new HandleCriticalUserComponentExceptionsLogger(this.unmarshalledJsRuntime);
+        public ILogger CreateLogger(string categoryName) => new HandleCriticalUserComponentExceptionsLogger(_jsRuntime);
 
         public void Dispose()
         {


### PR DESCRIPTION
This is an attempt to fix:
https://github.com/MudBlazor/TryMudBlazor/issues/105
https://github.com/MudBlazor/MudBlazor/issues/4418
https://github.com/MudBlazor/MudBlazor/issues/6222
https://github.com/MudBlazor/MudBlazor/discussions/6471

This is ported from [BlazorSnippet](https://github.com/BlazorSnippet/BlazorSnippet/) which is a continuation of the discontinued open source project BlazorREPL. The BlazorSnippet is under GPL-2.0 license, same as TryMudBlazor, so it should be fine.

If I understand it correctly, the problems is that for some reason the `Try.UserComponents.__Main` fails to load in `ExecuteUserDefinedConfiguration` for some cache reason, and this code potentially should fallback and recreate default `Try.UserComponents.dll` from the base64 and put in the cache.