### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,9 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/TryMudBlazor.Server/bin/Debug/net7.0/TryMudBlazor.Server.dll",
+            "program": "${workspaceFolder}/src/TryMudBlazor.Server/bin/Debug/net8.0/TryMudBlazor.Server.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src/TryMudBlazor.Servver",
+            "cwd": "${workspaceFolder}/src/TryMudBlazor.Server",
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
@@ -23,7 +23,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             "hosted": true,
-            "program": "${workspaceFolder}/src/TryMudBlazor.Server/bin/Debug/net7.0/TryMudBlazor.Server.dll",
+            "program": "${workspaceFolder}/src/TryMudBlazor.Server/bin/Debug/net8.0/TryMudBlazor.Server.dll",
             "cwd": "${workspaceFolder}/src/TryMudBlazor.Server",
             "browser": "edge",
             "env": {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/src/MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj
+++ b/src/MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <!--Used for the periodic table examples-->

--- a/src/Try.Core/Try.Core.csproj
+++ b/src/Try.Core/Try.Core.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.11" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.28" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="MudBlazor" Version="*" />
   </ItemGroup>
 

--- a/src/Try.Tests/Try.Tests.csproj
+++ b/src/Try.Tests/Try.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
+++ b/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <PublishTrimmed>false</PublishTrimmed>
+    <WasmEnableWebcil>false</WasmEnableWebcil>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
-    <PackageReference Include="FluentValidation" Version="11.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.3" />
     <PackageReference Include="MudBlazor" Version="*" />
   </ItemGroup>
 

--- a/src/TryMudBlazor.Client/wwwroot/editor/main.js
+++ b/src/TryMudBlazor.Client/wwwroot/editor/main.js
@@ -210,7 +210,7 @@ window.Try.CodeExecution = window.Try.CodeExecution || (function () {
                 return;
             }
 
-            const cache = await caches.open('blazor-resources-/');
+            const cache = await caches.open('dotnet-resources-/');
 
             const cacheKeys = await cache.keys();
             const userComponentsDllCacheKey = cacheKeys.find(x => x.url.indexOf('Try.UserComponents.dll') > -1);

--- a/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
+++ b/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <UserSecretsId>1fd261c7-898b-40dc-b869-d96c4b787fc1</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.0" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.3" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UserComponents/Try.UserComponents.csproj
+++ b/src/UserComponents/Try.UserComponents.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated packages
- Declared target framework in Dependency.Build.props
- Most importantly updated the cache from `blazor-resources-/` to `dotnet-resources-/`.