### PR TITLE
First load code editor light theme

### DIFF
--- a/src/TryMudBlazor.Client/wwwroot/editor/main.js
+++ b/src/TryMudBlazor.Client/wwwroot/editor/main.js
@@ -111,7 +111,7 @@ window.Try.Editor = window.Try.Editor || (function () {
     return {
         create: function (id, value, language) {
             if (!id) { return; }
-            let _theme = "default";
+            let _theme = "vs-dark";
             let userPreferences = localStorage.getItem("userPreferences");
             if (userPreferences) {
                 const userPreferencesJSON = JSON.parse(userPreferences);


### PR DESCRIPTION
If you delete the `userPreferences` key and reload the code editor will show in light mode and the rest will be in dark mode.

![Screenshot from 2024-03-27 08-20-25](https://github.com/MudBlazor/TryMudBlazor/assets/1698401/de2d57f3-2fca-4085-a78c-5fbc0be9f4a5)
