### PR TITLE
Add missing MudPopoverProvider

### DIFF
--- a/src/TryMudBlazor.Client/Shared/EmptyLayout.razor
+++ b/src/TryMudBlazor.Client/Shared/EmptyLayout.razor
@@ -2,6 +2,7 @@
 @inherits LayoutComponentBase
 
 <MudThemeProvider IsDarkMode="@LayoutService.IsDarkMode" />
+<MudPopoverProvider />
 
 <div class="main">
 	<div class="content px-4">

--- a/src/TryMudBlazor.Client/Shared/MainLayout.razor
+++ b/src/TryMudBlazor.Client/Shared/MainLayout.razor
@@ -2,6 +2,7 @@
 
 <MudThemeProvider @ref="@_mudThemeProvider" IsDarkMode="@LayoutService.IsDarkMode" IsDarkModeChanged="LayoutService.SetDarkMode"/>
 <TryThemeProvider IsDarkMode="@LayoutService.IsDarkMode"/>
+<MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
 


### PR DESCRIPTION
Fixes the problem that the popovers don't show in snippet unless `<MudPopoverProvider/>` is added.