### PR TITLE
Enable WasmFingerprintAssets for cache busting

### DIFF
--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -53,7 +53,7 @@
             ConfigurationName: "Blazor",
             Extensions: ImmutableArray<RazorExtension>.Empty);
 
-        public static async Task InitAsync(Func<ICollection<string>, ValueTask<IReadOnlyList<byte[]>>> getReferencedDllsBytesFunc)
+        public static async Task InitAsync(Func<IReadOnlyCollection<string>, ValueTask<IReadOnlyList<byte[]>>> getReferencedDllsBytesFunc)
         {
 
             var basicReferenceAssemblyRoots = new[]

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -79,9 +79,9 @@
                 .Select(an => an.Name)
                 .ToHashSet());
 
-             var basicReferenceAssemblies = assemblyNames
-                 .Select(peImage => MetadataReference.CreateFromImage(peImage, MetadataReferenceProperties.Assembly))
-                 .ToList();
+            var basicReferenceAssemblies = assemblyNames
+                .Select(peImage => MetadataReference.CreateFromImage(peImage, MetadataReferenceProperties.Assembly))
+                .ToList();
 
             _baseCompilation = CSharpCompilation.Create(
                 DefaultRootNamespace,

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -55,7 +55,6 @@
 
         public static async Task InitAsync(Func<IReadOnlyCollection<string>, ValueTask<IReadOnlyList<byte[]>>> getReferencedDllsBytesFunc)
         {
-
             var basicReferenceAssemblyRoots = new[]
             {
                 typeof(Console).Assembly, // System.Console
@@ -76,7 +75,7 @@
                 [
                     assembly.GetName()
                 ]))
-                .Select(an => an.Name)
+                .Select(assemblyName => assemblyName.Name)
                 .ToHashSet());
 
             var basicReferenceAssemblies = assemblyNames

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -1,7 +1,6 @@
 ﻿namespace Try.Core
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.ComponentModel.DataAnnotations;
@@ -25,16 +24,18 @@
         public const string DefaultRootNamespace = $"{nameof(Try)}.{nameof(UserComponents)}";
 
         private const string WorkingDirectory = "/TryMudBlazor/";
-        private const string DefaultImports = @"@using System.ComponentModel.DataAnnotations
-@using System.Linq
-@using System.Net.Http
-@using System.Net.Http.Json
-@using Microsoft.AspNetCore.Components.Forms
-@using Microsoft.AspNetCore.Components.Routing
-@using Microsoft.AspNetCore.Components.Web
-@using Microsoft.JSInterop
-@using MudBlazor
-";
+        private static readonly string[] DefaultImports =
+        [
+            "@using System.ComponentModel.DataAnnotations",
+            "@using System.Linq",
+            "@using System.Net.Http",
+            "@using System.Net.Http.Json",
+            "@using Microsoft.AspNetCore.Components.Forms",
+            "@using Microsoft.AspNetCore.Components.Routing",
+            "@using Microsoft.AspNetCore.Components.Web",
+            "@using Microsoft.JSInterop",
+            "@using MudBlazor"
+        ];
 
         private const string MudBlazorServices = @"
 <MudDialogProvider FullWidth=""true"" MaxWidth=""MaxWidth.ExtraSmall"" />
@@ -104,10 +105,7 @@
             ICollection<CodeFile> codeFiles,
             Func<string, Task> updateStatusFunc) // TODO: try convert to event
         {
-            if (codeFiles == null)
-            {
-                throw new ArgumentNullException(nameof(codeFiles));
-            }
+            ArgumentNullException.ThrowIfNull(codeFiles);
 
             var cSharpResults = await this.CompileToCSharpAsync(codeFiles, updateStatusFunc);
 
@@ -261,16 +259,16 @@
         }
 
         private RazorProjectEngine CreateRazorProjectEngine(IReadOnlyList<MetadataReference> references) =>
-            RazorProjectEngine.Create(configuration, fileSystem, b =>
+            RazorProjectEngine.Create(configuration, fileSystem, builder =>
             {
-                b.SetRootNamespace(DefaultRootNamespace);
-                b.AddDefaultImports(DefaultImports);
+                builder.SetRootNamespace(DefaultRootNamespace);
+                builder.AddDefaultImports(DefaultImports);
 
                 // Features that use Roslyn are mandatory for components
-                CompilerFeatures.Register(b);
+                CompilerFeatures.Register(builder);
 
-                b.Features.Add(new CompilationTagHelperFeature());
-                b.Features.Add(new DefaultMetadataReferenceFeature { References = references });
+                builder.Features.Add(new CompilationTagHelperFeature());
+                builder.Features.Add(new DefaultMetadataReferenceFeature { References = references });
             });
     }
 }

--- a/src/TryMudBlazor.Client/Models/TryConstants.cs
+++ b/src/TryMudBlazor.Client/Models/TryConstants.cs
@@ -2,24 +2,25 @@
 {
     public static class Try
     {
-        public static string Initialize = "Try.initialize";
-        public static string ChangeDisplayUrl = "Try.changeDisplayUrl";
-        public static string ReloadIframe = "Try.reloadIframe";
-        public static string Dispose = "Try.dispose";
+        public const string Initialize = "Try.initialize";
+        public const string ChangeDisplayUrl = "Try.changeDisplayUrl";
+        public const string ReloadIframe = "Try.reloadIframe";
+        public const string Dispose = "Try.dispose";
         public static class Editor
         {
-            public static string Create = "Try.Editor.create";
-            public static string GetValue = "Try.Editor.getValue";
-            public static string SetValue = "Try.Editor.setValue";
-            public static string SetLangugage = "Try.Editor.setLanguage";
-            public static string Focus = "Try.Editor.focus";
-            public static string SetTheme = "Try.Editor.setTheme";
-            public static string Dispose = "Try.Editor.dispose";
+            public const string Create = "Try.Editor.create";
+            public const string GetValue = "Try.Editor.getValue";
+            public const string SetValue = "Try.Editor.setValue";
+            public const string SetLangugage = "Try.Editor.setLanguage";
+            public const string Focus = "Try.Editor.focus";
+            public const string SetTheme = "Try.Editor.setTheme";
+            public const string Dispose = "Try.Editor.dispose";
         }
 
         public static class CodeExecution
         {
-            public static string UpdateUserComponentsDLL = "Try.CodeExecution.updateUserComponentsDll";
+            public const string GetCompilationDlls = "Try.CodeExecution.getCompilationDlls";
+            public const string UpdateUserComponentsDll = "Try.CodeExecution.updateUserComponentsDll";
         }
     }
 }

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -201,7 +201,7 @@
             if (compilationResult?.AssemblyBytes?.Length > 0)
             {
                 // Make sure the DLL is updated before reloading the user page
-                await this.JsRuntime.InvokeVoidAsync(Try.CodeExecution.UpdateUserComponentsDLL, compilationResult.AssemblyBytes);
+                await this.JsRuntime.InvokeVoidAsync(Try.CodeExecution.UpdateUserComponentsDll, compilationResult.AssemblyBytes);
 
                 // TODO: Add error page in iframe
                 this.JsRuntime.InvokeVoid(Try.ReloadIframe, "user-page-window", MainUserPagePath);

--- a/src/TryMudBlazor.Client/Program.cs
+++ b/src/TryMudBlazor.Client/Program.cs
@@ -55,7 +55,7 @@ namespace TryMudBlazor.Client
                 var actualException = exception is TargetInvocationException tie ? tie.InnerException : exception;
                 await Console.Error.WriteLineAsync($"Error on app startup: {actualException}");
 
-                jsRuntime.InvokeVoid(Try.CodeExecution.UpdateUserComponentsDLL, CoreConstants.DefaultUserComponentsAssemblyBytes);
+                jsRuntime.InvokeVoid(Try.CodeExecution.UpdateUserComponentsDll, CoreConstants.DefaultUserComponentsAssemblyBytes);
             }
 
             await builder.Build().RunAsync();

--- a/src/TryMudBlazor.Client/Services/HandleCriticalUserComponentExceptionsLogger.cs
+++ b/src/TryMudBlazor.Client/Services/HandleCriticalUserComponentExceptionsLogger.cs
@@ -28,7 +28,7 @@
         {
             if (exception?.ToString()?.Contains(CompilationService.DefaultRootNamespace) ?? false)
             {
-                _jsRuntime.InvokeVoid(Try.CodeExecution.UpdateUserComponentsDLL, CoreConstants.DefaultUserComponentsAssemblyBytes);
+                _jsRuntime.InvokeVoid(Try.CodeExecution.UpdateUserComponentsDll, CoreConstants.DefaultUserComponentsAssemblyBytes);
             }
         }
 

--- a/src/TryMudBlazor.Client/Shared/MainLayout.razor.cs
+++ b/src/TryMudBlazor.Client/Shared/MainLayout.razor.cs
@@ -37,7 +37,7 @@
             }
         }
 
-        private ValueTask<IReadOnlyList<byte[]>> GetReferenceAssembliesStreamsAsync(IEnumerable<string> referenceAssemblyNames)
+        private ValueTask<IReadOnlyList<byte[]>> GetReferenceAssembliesStreamsAsync(IReadOnlyCollection<string> referenceAssemblyNames)
         {
             return JsRuntime.InvokeAsync<IReadOnlyList<byte[]>>(CodeExecution.GetCompilationDlls, new List<string>(referenceAssemblyNames) { "netstandard" });
         }

--- a/src/TryMudBlazor.Client/Shared/MainLayout.razor.cs
+++ b/src/TryMudBlazor.Client/Shared/MainLayout.razor.cs
@@ -1,32 +1,28 @@
 ﻿namespace TryMudBlazor.Client.Shared
 {
     using System;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+    using Microsoft.JSInterop;
     using MudBlazor;
     using Services;
     using Try.Core;
-    using TryMudBlazor.Client;
+    using static TryMudBlazor.Client.Models.Try;
 
     public partial class MainLayout : LayoutComponentBase, IDisposable
     {
-        [Inject] public HttpClient HttpClient { get; set; }
-        [Inject] private LayoutService LayoutService { get; set; }
-
         private MudThemeProvider _mudThemeProvider;
+
+        [Inject]
+        private LayoutService LayoutService { get; set; }
+
+        [Inject]
+        private IJSRuntime JsRuntime { get; set; }
 
         protected override void OnInitialized()
         {
             LayoutService.MajorUpdateOccured += LayoutServiceOnMajorUpdateOccured;
             base.OnInitialized();
-        }
-
-        protected override async Task OnInitializedAsync()
-        {
-            await CompilationService.InitAsync(this.HttpClient);
-
-            await base.OnInitializedAsync();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -36,8 +32,14 @@
             if (firstRender)
             {
                 await ApplyUserPreferences();
+                await CompilationService.InitAsync(GetReferenceAssembliesStreamsAsync);
                 StateHasChanged();
             }
+        }
+
+        private ValueTask<IReadOnlyList<byte[]>> GetReferenceAssembliesStreamsAsync(IEnumerable<string> referenceAssemblyNames)
+        {
+            return JsRuntime.InvokeAsync<IReadOnlyList<byte[]>>(CodeExecution.GetCompilationDlls, new List<string>(referenceAssemblyNames) { "netstandard" });
         }
 
         private async Task ApplyUserPreferences()

--- a/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
+++ b/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <PublishTrimmed>false</PublishTrimmed>
     <WasmEnableWebcil>false</WasmEnableWebcil>
-    <WasmFingerprintAssets>false</WasmFingerprintAssets>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `HttpClient` method has been removed, and DLL data is now retrieved directly from the `dotnet-resources-/`.
This allows cache busting to be applied via `WasmFingerprintAssets`. 

Previously, when running from `TryMudBlazor.Server`, accessing links like `https://localhost:5001/_framework/Microsoft.AspNetCore.Components.WebAssembly.dll` would result in a 404 error. The correct link should have been `https://localhost:5001/_framework/Microsoft.AspNetCore.Components.Forms.vnx3zz3bws.dll`, but we couldn't retrieve the fingerprint (e.g., `vnx3zz3bws`) for the DLLs. It seems the legacy method of hosting WASM+ASP.NET Core together doesn't fully support this feature because the `ResourceAssetCollection` didn't return the necessary fingerprint information.
Therefore, using JS is the most optimal solution.

This approach works for both running as standalone WASM from `TryMudBlazor.Client` and the cohosted version from `TryMudBlazor.Server`.

When testing, please ensure to test both versions.