### PR TITLE
Fix Dark Mode Toggle

### DIFF
--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -282,6 +282,7 @@
             await LayoutService.ToggleDarkMode();
             string theme = LayoutService.IsDarkMode ? "vs-dark" : "default";
             this.JsRuntime.InvokeVoid(Try.Editor.SetTheme, theme);
+            // LayoutService calls StateHasChanged, we need the updated <style> tags for updateIframeTheme to work
             await Task.Yield();
             await JsRuntime.InvokeVoidAsync("updateIframeTheme");
         }

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -282,6 +282,8 @@
             await LayoutService.ToggleDarkMode();
             string theme = LayoutService.IsDarkMode ? "vs-dark" : "default";
             this.JsRuntime.InvokeVoid(Try.Editor.SetTheme, theme);
+            await Task.Yield();
+            await JsRuntime.InvokeVoidAsync("updateIframeTheme");
         }
     }
 }

--- a/src/TryMudBlazor.Client/wwwroot/index.html
+++ b/src/TryMudBlazor.Client/wwwroot/index.html
@@ -61,13 +61,29 @@
     <script src="_content/MudBlazor/MudBlazor.min.js?v=#{CACHE_TOKEN}#"></script>
     <script src="editor/main.js?v=#{CACHE_TOKEN}#"></script>
     <script type="text/javascript">
-        window.addEventListener('storage', (e) => {
-            if (e.key == "userPreferences") {
-                const mudblazorTheme = parent.document.getElementsByTagName('style')[4];
-                const iFrameTheme = document.getElementsByTagName('style')[3];
-                iFrameTheme.innerHTML = mudblazorTheme.innerHTML;
+        function updateIframeTheme() {
+            const mudblazorTheme = parent.document.querySelector('.mud-theme-provider') || parent.document.getElementsByTagName('style')[3];
+
+            if (mudblazorTheme) {
+                // Find the iframe
+                const userPageIframe = parent.document.getElementById('user-page-window');
+
+                if (userPageIframe && userPageIframe.contentDocument) {
+                    const iframeDoc = userPageIframe.contentDocument;
+                    const iFrameTheme = iframeDoc.querySelector('.mud-theme-provider') || iframeDoc.getElementsByTagName('style')[2];
+
+                    if (iFrameTheme) {
+                        iFrameTheme.innerHTML = mudblazorTheme.innerHTML;
+                    } else {
+                        //console.error('Could not find or fallback to the theme element in the iframe.');
+                    }
+                } else {
+                    //console.error('Could not find the iframe or access its content document.');
+                }
+            } else {
+                console.error('Could not find the parent theme element.');
             }
-        });
+        }
     </script>
 </body>
 

--- a/src/TryMudBlazor.Client/wwwroot/index.html
+++ b/src/TryMudBlazor.Client/wwwroot/index.html
@@ -74,12 +74,8 @@
 
                     if (iFrameTheme) {
                         iFrameTheme.innerHTML = mudblazorTheme.innerHTML;
-                    } else {
-                        //console.error('Could not find or fallback to the theme element in the iframe.');
-                    }
-                } else {
-                    //console.error('Could not find the iframe or access its content document.');
-                }
+                    } 
+                } 
             } else {
                 console.error('Could not find the parent theme element.');
             }


### PR DESCRIPTION
Fixed dark mode toggle by changing javascript to be just a function instead of a trigger and calling the function after the StateHasChanged. Modified the function to match future "mud-theme-provider" className or the current index.html structure in that order.