### PR TITLE
TryMudBlazor.Client -> Copy wwwroot folder directly to Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,4 @@ Client/Properties/ServiceDependencies/TryMudBlazor - Web Deploy/
 # Rider idea folder
 .idea/
 *.DS_Store
+/src/TryMudBlazor.Server/wwwroot/client

--- a/src/TryMudBlazor.Server/Program.cs
+++ b/src/TryMudBlazor.Server/Program.cs
@@ -44,7 +44,7 @@ public class Program
 
         var version = GetVersion();
         var cacheBusting = $"v{version.Major}.{version.Minor}.{version.Build}";
-        app.MapFallbackToFile("index.html")
+        app.MapFallbackToFile("client/index.html")
             .CacheOutput(policy => policy.SetVaryByQuery("cachebust", cacheBusting));
 
         app.Run();

--- a/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
+++ b/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
@@ -19,4 +19,16 @@
     <ProjectReference Include="..\MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj" />
   </ItemGroup>
 
+    <!-- Copy the wwwroot output from TryMudBlazor.Client into this project's wwwroot/client directory -->
+    <ItemGroup>
+        <ClientWwwRootFiles Include="..\TryMudBlazor.Client\wwwroot\**\*" />
+    </ItemGroup>
+
+    <Target Name="CopyClientWwwRoot" AfterTargets="Build">
+        <Copy
+          SourceFiles="@(ClientWwwRootFiles)"
+          DestinationFiles="@(ClientWwwRootFiles->'$(ProjectDir)wwwroot\client\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+    </Target>    
+    
 </Project>


### PR DESCRIPTION
Added a git ignore to wwwroot/client folder in TryMudBlazor.Server
Added an MSBuild action to copy Client wwwroot to wwwroot/client after build
Redirected Program.cs of TryMudBlazor.Server to point to wwwroot/client/index.html for static loading
