### PR TITLE
Drop unused Microsoft.CodeAnalysis.CSharp.Features package

### DIFF
--- a/src/Try.Core/Try.Core.csproj
+++ b/src/Try.Core/Try.Core.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
     <PackageReference Include="MudBlazor" Version="*" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0-2.24555.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.13.0-2.24555.1" />
     <PackageReference Include="Microsoft.Net.Compilers.Razor.Toolset" Version="9.0.0-preview.24555.4" PrivateAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
   </ItemGroup>
   


### PR DESCRIPTION
Nothing uses `Microsoft.CodeAnalysis.CSharp.Features`; we only call into `Microsoft.CodeAnalysis.CSharp` and the Razor compiler. Since we publish untrimmed, the reference pulled Features, Workspaces, CSharp.Workspaces, Humanizer, Elfie, DiaSymReader and the System.Composition assemblies into every page load.

Release publish, `_framework` brotli total: 18.05 MB before, 13.28 MB after. Verified locally that compiling a snippet and reporting diagnostics still works without it.
