### PR TITLE
Fix diagnostic line numbers and auto-open the error list

### DIFF
--- a/src/Try.Core/CompilationDiagnostic.cs
+++ b/src/Try.Core/CompilationDiagnostic.cs
@@ -1,4 +1,4 @@
-﻿namespace Try.Core
+namespace Try.Core
 {
     using System.IO;
     using Microsoft.AspNetCore.Razor.Language;
@@ -12,6 +12,9 @@
 
         public string Description { get; set; }
 
+        /// <summary>
+        /// 1-based line in the user's source file, matching the editor gutter.
+        /// </summary>
         public int? Line { get; set; }
 
         public string File { get; set; }
@@ -25,20 +28,9 @@
                 return null;
             }
 
+            // The generated C# carries #line directives back to the .razor source, so the mapped
+            // span already points at the user's file. Roslyn lines are 0-based; the editor is 1-based.
             var mappedLineSpan = diagnostic.Location.GetMappedLineSpan();
-            var file = Path.GetFileName(mappedLineSpan.Path);
-            var line = mappedLineSpan.StartLinePosition.Line;
-
-            if (file != CoreConstants.MainComponentFilePath)
-            {
-                // Make it 1-based. Skip the main component where we add @page directive line
-                line++;
-            }
-            else
-            {
-                // Offset for MudProviders
-                line -= 4;
-            }
 
             return new CompilationDiagnostic
             {
@@ -46,8 +38,8 @@
                 Code = diagnostic.Descriptor.Id,
                 Severity = diagnostic.Severity,
                 Description = diagnostic.GetMessage(),
-                File = file,
-                Line = line,
+                File = Path.GetFileName(mappedLineSpan.Path),
+                Line = mappedLineSpan.StartLinePosition.Line + 1,
             };
         }
 
@@ -65,8 +57,7 @@
                 Severity = (DiagnosticSeverity)diagnostic.Severity,
                 Description = diagnostic.GetMessage(),
                 File = Path.GetFileName(diagnostic.Span.FilePath),
-
-                // Line = diagnostic.Span.LineIndex, // TODO: Find a way to calculate this
+                Line = diagnostic.Span.LineIndex + 1,
             };
         }
     }

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -83,9 +83,16 @@
             // netstandard facade is needed for libraries that target netstandard2.0
             assemblyNames.Add("netstandard");
 
-            var loadedByName = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(a => !a.IsDynamic && a.GetName().Name != null)
-                .ToDictionary(a => a.GetName().Name!, StringComparer.OrdinalIgnoreCase);
+            // The same assembly name can be loaded into more than one load context (the test host does this),
+            // so keep the first one rather than letting ToDictionary throw.
+            var loadedByName = new Dictionary<string, System.Reflection.Assembly>(StringComparer.OrdinalIgnoreCase);
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (!assembly.IsDynamic && assembly.GetName().Name is { } name)
+                {
+                    loadedByName.TryAdd(name, assembly);
+                }
+            }
 
             var references = new List<MetadataReference>();
             foreach (var name in assemblyNames)
@@ -236,7 +243,7 @@
                 fullPath,
                 fileName,
                 FileKinds.Component,
-                Encoding.UTF8.GetBytes(fileContent.TrimStart()));
+                Encoding.UTF8.GetBytes(fileContent));
         }
 
         private async Task<IReadOnlyList<CompileToCSharpResult>> CompileToCSharpAsync(

--- a/src/Try.Tests/CompilationDiagnosticTests.cs
+++ b/src/Try.Tests/CompilationDiagnosticTests.cs
@@ -1,0 +1,79 @@
+namespace Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using NUnit.Framework;
+    using Try.Core;
+
+    /// <summary>
+    /// Compiles small snippets through the real <see cref="CompilationService"/> and checks that
+    /// diagnostics point at the same 1-based line the user sees in the editor.
+    /// </summary>
+    public class CompilationDiagnosticTests
+    {
+        private CompilationService compilationService;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            await CompilationService.InitAsync();
+            compilationService = new CompilationService();
+        }
+
+        [Test]
+        public async Task CSharpErrorInMainComponentReportsEditorLine()
+        {
+            // Leading blank line on purpose: the default template starts with one and it must count.
+            const string main = "\n<MudText>hi</MudText>\n\n@code {\n    void Go()\n    {\n        int x = \"not an int\";\n    }\n}\n";
+
+            var result = await Compile(main);
+
+            var error = result.Diagnostics.Single(d => d.Code == "CS0029");
+            Assert.That(error.File, Is.EqualTo(CoreConstants.MainComponentFilePath));
+            Assert.That(error.Line, Is.EqualTo(7));
+        }
+
+        [Test]
+        public async Task CSharpErrorInSecondaryComponentReportsEditorLine()
+        {
+            const string main = "<Second />";
+            const string second = "<h1>Second</h1>\n@code {\n    int y = \"bad\";\n}\n";
+
+            var result = await Compile(main, ("Second.razor", second));
+
+            var error = result.Diagnostics.Single(d => d.Code == "CS0029");
+            Assert.That(error.File, Is.EqualTo("Second.razor"));
+            Assert.That(error.Line, Is.EqualTo(3));
+        }
+
+        [Test]
+        public async Task RazorErrorReportsEditorLine()
+        {
+            const string main = "<MudText>ok</MudText>\n<MudAlert>unclosed\n";
+
+            var result = await Compile(main);
+
+            var error = result.Diagnostics.First(d => d.Kind == CompilationDiagnosticKind.Razor && d.Severity == DiagnosticSeverity.Error);
+            Assert.That(error.File, Is.EqualTo(CoreConstants.MainComponentFilePath));
+            Assert.That(error.Line, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task ValidSnippetProducesAssembly()
+        {
+            var result = await Compile(CoreConstants.MainComponentDefaultFileContent);
+
+            Assert.That(result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
+            Assert.That(result.AssemblyBytes, Is.Not.Null.And.Not.Empty);
+        }
+
+        private Task<CompileToAssemblyResult> Compile(string mainContent, params (string path, string content)[] extraFiles)
+        {
+            var files = new List<CodeFile> { new() { Path = CoreConstants.MainComponentFilePath, Content = mainContent } };
+            files.AddRange(extraFiles.Select(f => new CodeFile { Path = f.path, Content = f.content }));
+            return compilationService.CompileToAssemblyAsync(files, updateStatusFunc: null);
+        }
+    }
+}

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -61,8 +61,6 @@
 
         private int WarningsCount => this.Diagnostics.Count(d => d.Severity == DiagnosticSeverity.Warning);
 
-        private bool AreDiagnosticsShown { get; set; }
-
         private string LoaderText { get; set; }
 
         private bool Loading { get; set; }
@@ -72,7 +70,6 @@
         private void ToggleDiagnostics()
         {
             ShowDiagnostics = !ShowDiagnostics;
-            AreDiagnosticsShown = ShowDiagnostics;
         }
 
         private string Version
@@ -181,7 +178,7 @@
                     this.UpdateLoaderTextAsync);
 
                 this.Diagnostics = compilationResult.Diagnostics.OrderByDescending(x => x.Severity).ThenBy(x => x.Code).ToList();
-                this.AreDiagnosticsShown = true;
+                this.ShowDiagnostics = this.ErrorsCount > 0 || this.WarningsCount > 0;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Error line numbers in `__Main.razor` were off by 6. Put `int x = "str";` on line 12 and the error list says line 6. Three things stacked up: `FromCSharpDiagnostic` still subtracts 4 lines for the MudProviders markup we used to prepend to the main component (we don't anymore), that same branch skips the +1 for 1-based lines, and `CreateRazorProjectItem` calls `TrimStart()` on the source, which eats the blank first line of the default template. Now every file gets `mapped line + 1` and the source isn't trimmed.

Razor diagnostics (RZ*) never had a line number; `Span.LineIndex` has it.

The error list also didn't open after a failed compile. `CompileAsync` sets `AreDiagnosticsShown`, but the panel is bound to `ShowDiagnostics`, so the flag went nowhere. Removed the dead property and set the right one.

Added tests that run the real compiler and check the reported lines. To make that work on desktop .NET, `InitAsync` now tolerates the same assembly name being loaded twice (the NUnit host does that) instead of throwing from `ToDictionary`.
