### PR TITLE
Handle snippet save failures and validate uploads server-side

### DIFF
--- a/src/Try.Tests/SnippetArchiveValidatorTests.cs
+++ b/src/Try.Tests/SnippetArchiveValidatorTests.cs
@@ -1,0 +1,76 @@
+namespace Tests
+{
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using NUnit.Framework;
+    using Try.Core;
+    using TryMudBlazor.Server.Utilities;
+
+    public class SnippetArchiveValidatorTests
+    {
+        [Test]
+        public void AcceptsAValidSnippetArchive()
+        {
+            var archive = SnippetsServiceTests.Zip(
+            [
+                new CodeFile { Path = "__Main.razor", Content = "<MudText>hello</MudText>" },
+                new CodeFile { Path = "Helper.cs", Content = "public class Helper { }" },
+            ]);
+
+            Assert.That(Validate(archive), Is.Null);
+        }
+
+        [Test]
+        public void RejectsBodiesThatAreNotZipArchives()
+        {
+            Assert.That(Validate(Encoding.UTF8.GetBytes("plain text, not a zip")), Is.EqualTo("The snippet must be a zip archive."));
+        }
+
+        [Test]
+        public void RejectsArchivesWithoutTheMainComponent()
+        {
+            var archive = SnippetsServiceTests.Zip([new CodeFile { Path = "Other.razor", Content = "<h1>x</h1>" }]);
+
+            Assert.That(Validate(archive), Is.EqualTo("No main component file provided."));
+        }
+
+        [Test]
+        public void RejectsEntriesWithForeignExtensions()
+        {
+            var archive = SnippetsServiceTests.Zip(
+            [
+                new CodeFile { Path = "__Main.razor", Content = "<MudText>hello</MudText>" },
+                new CodeFile { Path = "payload.exe", Content = "MZ" },
+            ]);
+
+            Assert.That(Validate(archive), Does.StartWith("File 'payload.exe' has invalid extension"));
+        }
+
+        [Test]
+        public void RejectsTooManyFiles()
+        {
+            var files = Enumerable.Range(0, SnippetArchiveValidator.MaxFiles + 1)
+                .Select(i => new CodeFile { Path = i == 0 ? "__Main.razor" : $"C{i}.razor", Content = "<h1>x</h1>" });
+
+            Assert.That(Validate(SnippetsServiceTests.Zip(files)), Is.EqualTo($"A snippet can contain at most {SnippetArchiveValidator.MaxFiles} files."));
+        }
+
+        [Test]
+        public void RejectsOversizedFiles()
+        {
+            var archive = SnippetsServiceTests.Zip(
+            [
+                new CodeFile { Path = "__Main.razor", Content = new string('x', SnippetArchiveValidator.MaxFileBytes + 1) },
+            ]);
+
+            Assert.That(Validate(archive), Does.StartWith("File '__Main.razor' is larger than"));
+        }
+
+        private static string Validate(byte[] body)
+        {
+            using var stream = new MemoryStream(body);
+            return SnippetArchiveValidator.Validate(stream);
+        }
+    }
+}

--- a/src/Try.Tests/SnippetsServiceTests.cs
+++ b/src/Try.Tests/SnippetsServiceTests.cs
@@ -109,6 +109,17 @@ namespace Tests
             Assert.ThrowsAsync<HttpRequestException>(() => service.GetSnippetContentAsync(ValidSnippetId));
         }
 
+        [TestCase("a")]
+        [TestCase("")]
+        [TestCase("cacbacaeeafhcaf")]
+        [TestCase("cacbacaeeafhcafjj")]
+        [TestCase("cacbacaeeafhcaf1")]
+        [TestCase("cacbacaeeafhca-j")]
+        public void DecodeRejectsIdsOfTheWrongShape(string encoded)
+        {
+            Assert.Throws<InvalidDataException>(() => DecodeSnippetId(encoded));
+        }
+
         [Test]
         public void TestEncodeDecode()
         {

--- a/src/Try.Tests/SnippetsServiceTests.cs
+++ b/src/Try.Tests/SnippetsServiceTests.cs
@@ -2,6 +2,13 @@ namespace Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Options;
     using NUnit.Framework;
@@ -10,58 +17,96 @@ namespace Tests
     using TryMudBlazor.Client.Services;
     using static TryMudBlazor.Server.Utilities.SnippetsEncoder;
 
-    /// <summary>
-    /// Please note this is an integration test
-    /// It needs blob storage backend to work
-    /// You need an access key for the storage account in your secreets file
-    /// under the server project do the following
-    /// dotnet secrets init
-    /// dotnet user-secrets set "SnippetsAccessKey" "yourlongkeyfromazureportal"
-    /// </summary>
-
-    public class Tests
+    public class SnippetsServiceTests
     {
-        private readonly List<CodeFile> codeFiles = new List<CodeFile>();
-        private IOptions<SnippetsOptions> snippetsOptions;
+        private const string ValidSnippetId = "cacbacaeeafhcafj"; // 16 letters, like the server produces
+
+        private List<CodeFile> codeFiles;
 
         [SetUp]
         public void Setup()
         {
-            var codeFile = new CodeFile() { Path = "__Main.razor" };
-            codeFile.Content = "<MudDatePicker/>";
-            codeFiles.Add(codeFile);
-            var codeFile2 = new CodeFile() { Path = "Test.razor" };
-            codeFile2.Content = "<h1>Test</h1>";
-            codeFiles.Add(codeFile2);
-            snippetsOptions = Options.Create(new SnippetsOptions() { SnippetsService = "api/snippets" });
-
-        }
-
-
-        [Test]
-        [Ignore("Investigate failure")]
-        public async Task TestGet()
-        {
-            var snippetService = new SnippetsService(snippetsOptions, new HttpClient(), new MockNavigationManager());
-            var codeFiles = await snippetService.GetSnippetContentAsync("2021020540572059");
-            Assert.That(codeFiles, Is.Not.Null);
+            codeFiles =
+            [
+                new CodeFile { Path = "__Main.razor", Content = "<MudDatePicker/>" },
+                new CodeFile { Path = "Test.razor", Content = "<h1>Test</h1>" },
+            ];
         }
 
         [Test]
-        [Ignore("Investigate failure")]
-        public async Task TestPut()
+        public async Task SaveReturnsTheIdTheServerProduced()
         {
-            var snippetService = new SnippetsService(snippetsOptions, new HttpClient(), new MockNavigationManager());
-            var id = await snippetService.SaveSnippetAsync(codeFiles);
-            Assert.That(id, Is.Not.Null);
-            Console.WriteLine(id);
-            var savedCodeFiles = await snippetService.GetSnippetContentAsync(id);
-            List<CodeFile> savedCodeFilesList = new List<CodeFile>(savedCodeFiles);
-            for (int i = 0; i < codeFiles.Count; i++)
-            {
-                Assert.That(codeFiles[i].Path, Is.EqualTo(savedCodeFilesList[i].Path));
-                Assert.That(codeFiles[i].Content, Is.EqualTo(savedCodeFilesList[i].Content));
-            }
+            var handler = new FakeHandler(_ => Text(HttpStatusCode.OK, ValidSnippetId));
+            var service = CreateService(handler);
+
+            var id = await service.SaveSnippetAsync(codeFiles);
+
+            Assert.That(id, Is.EqualTo(ValidSnippetId));
+            Assert.That(handler.Requests.Single().Method, Is.EqualTo(HttpMethod.Post));
+            Assert.That(handler.Requests.Single().RequestUri!.ToString(), Is.EqualTo("https://localhost:5001/api/snippets"));
+        }
+
+        [Test]
+        public void SaveThrowsOnServerError()
+        {
+            var service = CreateService(new FakeHandler(_ => Text(HttpStatusCode.InternalServerError, "Azure.Identity.CredentialUnavailableException: ...")));
+
+            Assert.ThrowsAsync<HttpRequestException>(() => service.SaveSnippetAsync(codeFiles));
+        }
+
+        [Test]
+        public void SaveThrowsWhenASuccessResponseIsNotASnippetId()
+        {
+            var service = CreateService(new FakeHandler(_ => Text(HttpStatusCode.OK, "<!DOCTYPE html><html>...")));
+
+            Assert.ThrowsAsync<HttpRequestException>(() => service.SaveSnippetAsync(codeFiles));
+        }
+
+        [Test]
+        public void SaveSurfacesTheServersValidationMessage()
+        {
+            var service = CreateService(new FakeHandler(_ => Json(HttpStatusCode.BadRequest, "{\"title\":\"Bad Request\",\"status\":400,\"detail\":\"A snippet can contain at most 20 files.\"}")));
+
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveSnippetAsync(codeFiles));
+            Assert.That(exception!.Message, Is.EqualTo("A snippet can contain at most 20 files."));
+        }
+
+        [Test]
+        public void SaveRejectsInvalidFilesBeforeCallingTheServer()
+        {
+            var handler = new FakeHandler(_ => Text(HttpStatusCode.OK, ValidSnippetId));
+            var service = CreateService(handler);
+
+            Assert.ThrowsAsync<InvalidOperationException>(() => service.SaveSnippetAsync([new CodeFile { Path = "Test.razor", Content = "<h1/>" }]));
+            Assert.That(handler.Requests, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetReturnsTheFilesFromTheServerArchive()
+        {
+            var service = CreateService(new FakeHandler(_ => Bytes(HttpStatusCode.OK, Zip(codeFiles))));
+
+            var files = (await service.GetSnippetContentAsync(ValidSnippetId)).ToList();
+
+            Assert.That(files.Select(f => f.Path), Is.EqualTo(codeFiles.Select(f => f.Path)));
+            Assert.That(files.Select(f => f.Content), Is.EqualTo(codeFiles.Select(f => f.Content)));
+        }
+
+        [TestCase(HttpStatusCode.NotFound)]
+        [TestCase(HttpStatusCode.BadRequest)]
+        public void GetTreatsAMissingSnippetAsAnInvalidId(HttpStatusCode statusCode)
+        {
+            var service = CreateService(new FakeHandler(_ => Text(statusCode, string.Empty)));
+
+            Assert.ThrowsAsync<ArgumentException>(() => service.GetSnippetContentAsync(ValidSnippetId));
+        }
+
+        [Test]
+        public void GetThrowsOnServerError()
+        {
+            var service = CreateService(new FakeHandler(_ => Text(HttpStatusCode.InternalServerError, string.Empty)));
+
+            Assert.ThrowsAsync<HttpRequestException>(() => service.GetSnippetContentAsync(ValidSnippetId));
         }
 
         [Test]
@@ -69,13 +114,51 @@ namespace Tests
         {
             const string snippetId = "2021020540572059";
             var encoded = EncodeSnippetId(snippetId);
-            Console.WriteLine(encoded);
             var decoded = DecodeSnippetId(encoded);
-            Console.WriteLine(decoded);
             Assert.That(snippetId, Is.EqualTo(decoded));
             var encoded2 = EncodeSnippetId(snippetId);
-            Console.WriteLine(encoded2);
             Assert.That(encoded, Is.Not.EqualTo(encoded2));
+        }
+
+        private static SnippetsService CreateService(HttpMessageHandler handler)
+        {
+            var options = Options.Create(new SnippetsOptions { SnippetsService = "api/snippets" });
+            return new SnippetsService(options, new HttpClient(handler), new MockNavigationManager());
+        }
+
+        internal static byte[] Zip(IEnumerable<CodeFile> files)
+        {
+            using var stream = new MemoryStream();
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                foreach (var file in files)
+                {
+                    using var entry = archive.CreateEntry(file.Path).Open();
+                    entry.Write(Encoding.UTF8.GetBytes(file.Content));
+                }
+            }
+
+            return stream.ToArray();
+        }
+
+        private static HttpResponseMessage Text(HttpStatusCode status, string body) =>
+            new(status) { Content = new StringContent(body, Encoding.UTF8, "text/plain") };
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+            new(status) { Content = new StringContent(body, Encoding.UTF8, "application/problem+json") };
+
+        private static HttpResponseMessage Bytes(HttpStatusCode status, byte[] body) =>
+            new(status) { Content = new ByteArrayContent(body) };
+
+        private sealed class FakeHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+        {
+            public List<HttpRequestMessage> Requests { get; } = [];
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Requests.Add(request);
+                return Task.FromResult(respond(request));
+            }
         }
     }
 }

--- a/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
+++ b/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
@@ -3,6 +3,7 @@ namespace TryMudBlazor.Client.Components
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
     using Microsoft.JSInterop;
@@ -64,6 +65,10 @@ namespace TryMudBlazor.Client.Components
             catch (InvalidOperationException ex)
             {
                 Snackbar.Add(ex.Message, Severity.Error);
+            }
+            catch (HttpRequestException)
+            {
+                Snackbar.Add("Could not save the snippet. Please try again later.", Severity.Error);
             }
             catch (Exception)
             {

--- a/src/TryMudBlazor.Client/Services/SnippetsService.cs
+++ b/src/TryMudBlazor.Client/Services/SnippetsService.cs
@@ -1,10 +1,13 @@
-﻿namespace TryMudBlazor.Client.Services
+namespace TryMudBlazor.Client.Services
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.IO.Compression;
+    using System.Linq;
+    using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Json;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
@@ -25,9 +28,13 @@
             this.snippetsService = $"{navigationManager.BaseUri}{snippetsOptions.Value.SnippetsService}";
         }
 
+        /// <summary>
+        /// Uploads the files and returns the public snippet ID.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The files fail validation or the server rejected them.</exception>
+        /// <exception cref="HttpRequestException">The server could not be reached or returned an error.</exception>
         public async Task<string> SaveSnippetAsync(IEnumerable<CodeFile> codeFiles)
         {
-            var snippetId = string.Empty;
             if (codeFiles == null)
             {
                 throw new ArgumentNullException(nameof(codeFiles));
@@ -39,30 +46,47 @@
                 throw new InvalidOperationException(codeFilesValidationError);
             }
 
-            using (var memoryStream = new MemoryStream())
+            using var memoryStream = new MemoryStream();
+            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
             {
-                using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
+                foreach (var codeFile in codeFiles)
                 {
-                    foreach (var codeFile in codeFiles)
-                    {
-                        var byteArray = Encoding.UTF8.GetBytes(codeFile.Content);
-                        var codeEntry = archive.CreateEntry(codeFile.Path);
-                        using var entryStream = codeEntry.Open();
-                        entryStream.Write(byteArray);
-                    }
+                    var byteArray = Encoding.UTF8.GetBytes(codeFile.Content);
+                    var codeEntry = archive.CreateEntry(codeFile.Path);
+                    using var entryStream = codeEntry.Open();
+                    entryStream.Write(byteArray);
                 }
+            }
 
-                memoryStream.Position = 0;
+            memoryStream.Position = 0;
 
-                var inputData = new StreamContent(memoryStream);
+            var inputData = new StreamContent(memoryStream);
 
-                var response = await this.httpClient.PostAsync(this.snippetsService, inputData);
-                snippetId = await response.Content.ReadAsStringAsync();
+            using var response = await this.httpClient.PostAsync(this.snippetsService, inputData);
+            if (response.StatusCode == HttpStatusCode.BadRequest)
+            {
+                // The server ran the same validation and explains what it rejected.
+                var reason = await ReadProblemDetailAsync(response);
+                throw new InvalidOperationException(reason ?? "The server rejected the snippet.");
+            }
+
+            response.EnsureSuccessStatusCode();
+
+            var snippetId = await response.Content.ReadAsStringAsync();
+            if (!IsServerSnippetId(snippetId))
+            {
+                // Anything else is an error page or a proxy response, never a snippet link.
+                throw new HttpRequestException("The server did not return a snippet ID.");
             }
 
             return snippetId;
         }
 
+        /// <summary>
+        /// Loads a snippet either from the server by its ID or from the compressed form embedded in the URL.
+        /// </summary>
+        /// <exception cref="ArgumentException">The ID is malformed or no snippet exists for it.</exception>
+        /// <exception cref="HttpRequestException">The server could not be reached or returned an error.</exception>
         public async Task<IEnumerable<CodeFile>> GetSnippetContentAsync(string snippetId)
         {
             if (string.IsNullOrWhiteSpace(snippetId))
@@ -70,32 +94,51 @@
                 throw new ArgumentException("Invalid snippet ID.", nameof(snippetId));
             }
 
-            IEnumerable<CodeFile> snippetFiles;
             if (snippetId.Length != SnippetIdLength)
             {
                 try
                 {
-                    snippetFiles = snippetId.ToCodeFiles();
+                    var snippetFiles = snippetId.ToCodeFiles();
                     var codeFilesValidationError = CodeFilesHelper.ValidateCodeFilesForSnippetCreation(snippetFiles);
                     if (!string.IsNullOrWhiteSpace(codeFilesValidationError))
                     {
                         throw new InvalidOperationException(codeFilesValidationError);
                     }
+
+                    return snippetFiles;
                 }
                 catch
                 {
                     throw new ArgumentException("Invalid snippet ID.", nameof(snippetId));
                 }
             }
-            else
+
+            using var response = await this.httpClient.GetAsync($"{this.snippetsService}/{snippetId}");
+            if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest)
             {
-                var reponse = await this.httpClient.GetAsync($"{this.snippetsService}/{snippetId}");
-                var zipStream = await reponse.Content.ReadAsStreamAsync();
-                zipStream.Position = 0;
-                snippetFiles = await ExtractSnippetFilesFromZip(zipStream);
+                throw new ArgumentException("Invalid snippet ID.", nameof(snippetId));
             }
 
-            return snippetFiles;
+            response.EnsureSuccessStatusCode();
+
+            using var zipStream = new MemoryStream(await response.Content.ReadAsByteArrayAsync());
+            return await ExtractSnippetFilesFromZip(zipStream);
+        }
+
+        private static bool IsServerSnippetId(string snippetId) =>
+            snippetId?.Length == SnippetIdLength && snippetId.All(char.IsAsciiLetter);
+
+        private static async Task<string> ReadProblemDetailAsync(HttpResponseMessage response)
+        {
+            try
+            {
+                var problem = await response.Content.ReadFromJsonAsync<ProblemPayload>();
+                return string.IsNullOrWhiteSpace(problem?.Detail) ? null : problem.Detail;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private static async Task<IEnumerable<CodeFile>> ExtractSnippetFilesFromZip(Stream zipStream)
@@ -110,6 +153,11 @@
             }
 
             return result;
+        }
+
+        private sealed class ProblemPayload
+        {
+            public string Detail { get; set; }
         }
     }
 }

--- a/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
+++ b/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
@@ -1,7 +1,9 @@
-﻿using Azure.Identity;
+using Azure;
+using Azure.Identity;
 using Azure.Storage;
 using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Mvc;
+using TryMudBlazor.Server.Utilities;
 using static TryMudBlazor.Server.Utilities.SnippetsEncoder;
 
 namespace TryMudBlazor.Server.Controllers;
@@ -45,21 +47,52 @@ public class SnippetsController : ControllerBase
     [HttpGet("{snippetId}")]
     public async Task<IActionResult> Get(string snippetId)
     {
-        snippetId = DecodeSnippetId(snippetId);
-        var blob = _containerClient.GetBlobClient(BlobPath(snippetId));
-        var response = await blob.DownloadAsync();
+        string decodedSnippetId;
+        try
+        {
+            decodedSnippetId = DecodeSnippetId(snippetId);
+        }
+        catch (InvalidDataException)
+        {
+            return Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Invalid snippet ID.");
+        }
+
+        var blob = _containerClient.GetBlobClient(BlobPath(decodedSnippetId));
         var zipStream = new MemoryStream();
-        await response.Value.Content.CopyToAsync(zipStream);
+        try
+        {
+            var response = await blob.DownloadAsync();
+            await response.Value.Content.CopyToAsync(zipStream);
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        {
+            return NotFound();
+        }
+
         zipStream.Position = 0;
 
         return File(zipStream, "application/octet-stream", "snippet.zip");
     }
 
     [HttpPost]
+    [RequestSizeLimit(SnippetArchiveValidator.MaxArchiveBytes)]
     public async Task<IActionResult> Post()
     {
+        // Buffer the upload so it can be validated before anything reaches storage.
+        var archiveStream = new MemoryStream();
+        await Request.Body.CopyToAsync(archiveStream);
+        archiveStream.Position = 0;
+
+        var validationError = SnippetArchiveValidator.Validate(archiveStream);
+        if (validationError is not null)
+        {
+            return Problem(statusCode: StatusCodes.Status400BadRequest, detail: validationError);
+        }
+
+        archiveStream.Position = 0;
+
         var newSnippetId = NewSnippetId();
-        await _containerClient.UploadBlobAsync(BlobPath(newSnippetId), Request.Body);
+        await _containerClient.UploadBlobAsync(BlobPath(newSnippetId), archiveStream);
 
         return Ok(EncodeSnippetId(newSnippetId));
     }

--- a/src/TryMudBlazor.Server/Program.cs
+++ b/src/TryMudBlazor.Server/Program.cs
@@ -16,6 +16,7 @@ public class Program
             });
         });
         builder.Services.AddControllers();
+        builder.Services.AddProblemDetails();
 
         var app = builder.Build();
 
@@ -26,7 +27,8 @@ public class Program
         }
         else
         {
-            app.UseExceptionHandler("/Error");
+            // Unhandled API errors become RFC 7807 responses; there is no /Error page to re-execute.
+            app.UseExceptionHandler();
             // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
             app.UseHsts();
         }
@@ -42,18 +44,8 @@ public class Program
 
         app.MapControllers();
 
-        var version = GetVersion();
-        var cacheBusting = $"v{version.Major}.{version.Minor}.{version.Build}";
-        app.MapFallbackToFile("index.html")
-            .CacheOutput(policy => policy.SetVaryByQuery("cachebust", cacheBusting));
+        app.MapFallbackToFile("index.html");
 
         app.Run();
-    }
-
-    private static Version GetVersion()
-    {
-        var version = typeof(MudBlazor._Imports).Assembly.GetName().Version;
-
-        return version ?? new Version(0, 0, 0);
     }
 }

--- a/src/TryMudBlazor.Server/Utilities/SnippetArchiveValidator.cs
+++ b/src/TryMudBlazor.Server/Utilities/SnippetArchiveValidator.cs
@@ -1,0 +1,59 @@
+using System.IO.Compression;
+using Try.Core;
+using TryMudBlazor.Client.Services;
+
+namespace TryMudBlazor.Server.Utilities;
+
+/// <summary>
+/// Checks an uploaded snippet archive before it is stored: it must be a zip of a few small
+/// .razor/.cs files that pass the same rules the client applies when creating a snippet.
+/// </summary>
+public static class SnippetArchiveValidator
+{
+    public const int MaxArchiveBytes = 512 * 1024;
+    public const int MaxFileBytes = 256 * 1024;
+    public const int MaxFiles = 20;
+
+    /// <summary>
+    /// Returns null when the archive is acceptable, otherwise a message describing the first problem.
+    /// </summary>
+    public static string? Validate(Stream archiveStream)
+    {
+        ZipArchive archive;
+        try
+        {
+            archive = new ZipArchive(archiveStream, ZipArchiveMode.Read, leaveOpen: true);
+        }
+        catch (InvalidDataException)
+        {
+            return "The snippet must be a zip archive.";
+        }
+
+        using (archive)
+        {
+            if (archive.Entries.Count == 0)
+            {
+                return "The snippet contains no files.";
+            }
+
+            if (archive.Entries.Count > MaxFiles)
+            {
+                return $"A snippet can contain at most {MaxFiles} files.";
+            }
+
+            var codeFiles = new List<CodeFile>(archive.Entries.Count);
+            foreach (var entry in archive.Entries)
+            {
+                if (entry.Length > MaxFileBytes)
+                {
+                    return $"File '{entry.FullName}' is larger than {MaxFileBytes / 1024} KB.";
+                }
+
+                using var reader = new StreamReader(entry.Open());
+                codeFiles.Add(new CodeFile { Path = entry.FullName, Content = reader.ReadToEnd() });
+            }
+
+            return CodeFilesHelper.ValidateCodeFilesForSnippetCreation(codeFiles);
+        }
+    }
+}

--- a/src/TryMudBlazor.Server/Utilities/SnippetIdEncoder.cs
+++ b/src/TryMudBlazor.Server/Utilities/SnippetIdEncoder.cs
@@ -73,8 +73,19 @@ public static class SnippetsEncoder
         return encoded;
     }
 
+    public const int SnippetIdLength = 16;
+
+    /// <summary>
+    /// Decodes a public snippet ID back to the 16-digit storage ID.
+    /// </summary>
+    /// <exception cref="InvalidDataException">The ID has the wrong length or contains characters outside the alphabet.</exception>
     public static string DecodeSnippetId(string encoded)
     {
+        if (encoded is null || encoded.Length != SnippetIdLength)
+        {
+            throw new InvalidDataException("Invalid snippet ID");
+        }
+
         var decoded = string.Empty;
 
         foreach (var letter in encoded)


### PR DESCRIPTION
`SaveSnippetAsync` never checked the response status; it read the body as the snippet id. If the API returns 500, the popover shows a "share link" made of the exception text and pushes it into the address bar (easy to reproduce locally where there are no Azure credentials). In production, `UseExceptionHandler("/Error")` re-executes to a route that doesn't exist and falls through to `index.html`, so you'd get the HTML shell as the id instead.

Client side: check the status on save and load, only accept a 16-letter id, show the server's message on a 400 and "Could not save the snippet" otherwise. Loading treats 404/400 as an invalid id, and reads the zip into a `MemoryStream` rather than seeking the response stream.

Server side: the POST endpoint took a body of any size and content and uploaded it straight to blob storage. It now has a 512 KB request limit, checks that the body is a zip, and runs the same `CodeFilesHelper` validation the client uses (razor/cs only, valid identifiers, must include `__Main.razor`, max 20 files of 256 KB). GET returns 400 for a malformed id (including wrong length, which used to throw in `BlobPath`) and 404 when the blob is missing. `Program.cs` uses `AddProblemDetails` + `UseExceptionHandler()` instead of the dead `/Error` route, and drops the `CacheOutput` call that had no output cache middleware behind it.

Replaced the two `[Ignore]`d Azure integration tests with tests over a fake `HttpMessageHandler`, plus tests for the archive validator and id decoding. The happy path against real storage wasn't exercised locally.
