### PR TITLE
Retry snippet upload on ID collision and generate IDs in UTC

### DIFF
--- a/src/Try.Tests/SnippetIdsTests.cs
+++ b/src/Try.Tests/SnippetIdsTests.cs
@@ -1,0 +1,48 @@
+namespace Tests
+{
+    using System;
+    using NUnit.Framework;
+    using TryMudBlazor.Server.Utilities;
+    using static TryMudBlazor.Server.Utilities.SnippetsEncoder;
+
+    public class SnippetIdsTests
+    {
+        [Test]
+        public void NewIdIsDateAndMillisecondOfDay()
+        {
+            var id = SnippetIds.New(new DateTime(2026, 9, 4, 13, 5, 7, 89, DateTimeKind.Utc));
+
+            // 13:05:07.089 = 47,107,089 ms into the day
+            Assert.That(id, Is.EqualTo("2026090447107089"));
+            Assert.That(id, Has.Length.EqualTo(SnippetIds.Length));
+        }
+
+        [Test]
+        public void EndOfDayStillFitsSixteenDigits()
+        {
+            var id = SnippetIds.New(new DateTime(2026, 12, 31, 23, 59, 59, 999, DateTimeKind.Utc));
+
+            Assert.That(id, Is.EqualTo("2026123186399999"));
+        }
+
+        [Test]
+        public void BlobPathSplitsIdIntoDateFolders()
+        {
+            Assert.That(SnippetIds.BlobPath("2026090447107089"), Is.EqualTo("2026/09/04/47107089"));
+        }
+
+        [Test]
+        public void BlobPathRejectsWrongLength()
+        {
+            Assert.Throws<ArgumentException>(() => SnippetIds.BlobPath("20260904"));
+        }
+
+        [Test]
+        public void IdSurvivesPublicEncoding()
+        {
+            var id = SnippetIds.New(DateTime.UtcNow);
+
+            Assert.That(DecodeSnippetId(EncodeSnippetId(id)), Is.EqualTo(id));
+        }
+    }
+}

--- a/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
+++ b/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
@@ -94,8 +94,6 @@ public class SnippetsController : ControllerBase
         return Ok(EncodeSnippetId(newSnippetId));
     }
 
-    // IDs are the millisecond of the day, so two saves in the same millisecond collide and the second
-    // upload fails with 409 BlobAlreadyExists. Retry with a fresh ID rather than failing the save.
     private async Task<string> UploadWithFreshIdAsync(MemoryStream archiveStream)
     {
         const int attempts = 5;

--- a/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
+++ b/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
@@ -57,7 +57,7 @@ public class SnippetsController : ControllerBase
             return Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Invalid snippet ID.");
         }
 
-        var blob = _containerClient.GetBlobClient(BlobPath(decodedSnippetId));
+        var blob = _containerClient.GetBlobClient(SnippetIds.BlobPath(decodedSnippetId));
         var zipStream = new MemoryStream();
         try
         {
@@ -89,34 +89,29 @@ public class SnippetsController : ControllerBase
             return Problem(statusCode: StatusCodes.Status400BadRequest, detail: validationError);
         }
 
-        archiveStream.Position = 0;
-
-        var newSnippetId = NewSnippetId();
-        await _containerClient.UploadBlobAsync(BlobPath(newSnippetId), archiveStream);
+        var newSnippetId = await UploadWithFreshIdAsync(archiveStream);
 
         return Ok(EncodeSnippetId(newSnippetId));
     }
 
-    private static string NewSnippetId()
+    // IDs are the millisecond of the day, so two saves in the same millisecond collide and the second
+    // upload fails with 409 BlobAlreadyExists. Retry with a fresh ID rather than failing the save.
+    private async Task<string> UploadWithFreshIdAsync(MemoryStream archiveStream)
     {
-        var yearFolder = DateTime.Now.Year;
-        var monthFolder = DateTime.Now.Month;
-        var dayFolder = DateTime.Now.Day;
-        var time = Convert.ToInt32(DateTime.Now.TimeOfDay.TotalMilliseconds);
-        var snippetTime = $"{time:D8}";
-
-        return $"{yearFolder:0000}{monthFolder:00}{dayFolder:00}{snippetTime:D8}";
-    }
-
-    private static string BlobPath(string snippetId)
-    {
-        var yearFolder = snippetId.Substring(0, 4);
-        var monthFolder = snippetId.Substring(4, 2);
-        var dayFolder = snippetId.Substring(6, 2);
-        var time = snippetId.Substring(8);
-        var snippetFolder = $"{yearFolder:0000}/{monthFolder:00}/{dayFolder:00}";
-        var snippetTime = $"{time:00000000}";
-
-        return $"{snippetFolder}/{snippetTime}";
+        const int attempts = 5;
+        for (var attempt = 1; ; attempt++)
+        {
+            var snippetId = SnippetIds.New();
+            archiveStream.Position = 0;
+            try
+            {
+                await _containerClient.UploadBlobAsync(SnippetIds.BlobPath(snippetId), archiveStream);
+                return snippetId;
+            }
+            catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status409Conflict && attempt < attempts)
+            {
+                await Task.Delay(1);
+            }
+        }
     }
 }

--- a/src/TryMudBlazor.Server/Utilities/SnippetIds.cs
+++ b/src/TryMudBlazor.Server/Utilities/SnippetIds.cs
@@ -1,0 +1,28 @@
+namespace TryMudBlazor.Server.Utilities;
+
+/// <summary>
+/// Storage IDs are 16 digits: yyyyMMdd followed by the millisecond of the day, zero padded to 8.
+/// The blob path is derived from the ID, so the layout is stable regardless of when it was generated.
+/// </summary>
+public static class SnippetIds
+{
+    public const int Length = 16;
+
+    public static string New() => New(DateTime.UtcNow);
+
+    public static string New(DateTime utcNow)
+    {
+        var millisecondOfDay = (int)utcNow.TimeOfDay.TotalMilliseconds;
+        return $"{utcNow:yyyyMMdd}{millisecondOfDay:D8}";
+    }
+
+    public static string BlobPath(string snippetId)
+    {
+        if (snippetId.Length != Length)
+        {
+            throw new ArgumentException($"Snippet IDs are {Length} digits.", nameof(snippetId));
+        }
+
+        return $"{snippetId[..4]}/{snippetId[4..6]}/{snippetId[6..8]}/{snippetId[8..]}";
+    }
+}


### PR DESCRIPTION
Snippet IDs are `yyyyMMdd` + millisecond of the day, so two saves in the same millisecond produce the same blob path. `UploadBlobAsync` refuses to overwrite, throws 409 `BlobAlreadyExists`, and the user gets the generic "could not save" error. The controller now retries with a fresh ID (up to 5 attempts, 1 ms apart) before giving up.

IDs were also generated from `DateTime.Now`, so the date folder depended on the App Service time zone. Switched to UTC. Existing snippets aren't affected since the path is derived from the ID, not from when it's read.

ID generation and the path split moved to `SnippetIds` with tests; the controller keeps the retry loop.
