### PR TITLE
Make Clear cache clear the compiled output and reload in place

### DIFF
--- a/src/TryMudBlazor.Client/Pages/Repl.razor
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor
@@ -50,6 +50,7 @@
         <div class="bottom-buttons">
             <MudTooltip Text="Clear compiled output and reload" Placement="Placement.Right">
                 <MudIconButton OnClick="@ClearCache"
+                               AriaLabel="Clear compiled output and reload"
                                Icon="@(LayoutService.IsDarkMode ? Icons.Material.Outlined.Cached : Icons.Material.Filled.Cached)"
                                Class="cache-button"
                                Color="@(LayoutService.IsDarkMode ? Color.Default : Color.Inherit)" />

--- a/src/TryMudBlazor.Client/Pages/Repl.razor
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor
@@ -50,7 +50,7 @@
         <div class="bottom-buttons">
             <MudTooltip Text="Clear compiled output and reload" Placement="Placement.Right">
                 <MudIconButton OnClick="@ClearCache"
-                               AriaLabel="Clear compiled output and reload"
+                               aria-label="Clear compiled output and reload"
                                Icon="@(LayoutService.IsDarkMode ? Icons.Material.Outlined.Cached : Icons.Material.Filled.Cached)"
                                Class="cache-button"
                                Color="@(LayoutService.IsDarkMode ? Color.Default : Color.Inherit)" />

--- a/src/TryMudBlazor.Client/Pages/Repl.razor
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor
@@ -48,9 +48,9 @@
         <span class="brand">Try MudBlazor</span>
 
         <div class="bottom-buttons">
-            <MudTooltip Text="Clear compiled output and reload" Placement="Placement.Right">
+            <MudTooltip Text="Clear cache" Placement="Placement.Right">
                 <MudIconButton OnClick="@ClearCache"
-                               aria-label="Clear compiled output and reload"
+                               aria-label="Clear cache"
                                Icon="@(LayoutService.IsDarkMode ? Icons.Material.Outlined.Cached : Icons.Material.Filled.Cached)"
                                Class="cache-button"
                                Color="@(LayoutService.IsDarkMode ? Color.Default : Color.Inherit)" />

--- a/src/TryMudBlazor.Client/Pages/Repl.razor
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor
@@ -48,7 +48,7 @@
         <span class="brand">Try MudBlazor</span>
 
         <div class="bottom-buttons">
-            <MudTooltip Text="Clear cache" Placement="Placement.Right">
+            <MudTooltip Text="Clear compiled output and reload" Placement="Placement.Right">
                 <MudIconButton OnClick="@ClearCache"
                                Icon="@(LayoutService.IsDarkMode ? Icons.Material.Outlined.Cached : Icons.Material.Filled.Cached)"
                                Class="cache-button"

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -278,7 +278,6 @@
 
         private void ClearCache()
         {
-            // Drop the compiled user assembly so the preview boots from the stock stub, then reload this page rather than bouncing to the landing page.
             this.JsRuntime.InvokeVoid(Try.CodeExecution.ClearUserComponentsDll);
             NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
         }

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -278,7 +278,10 @@
 
         private void ClearCache()
         {
-            NavigationManager.NavigateTo(NavigationManager.BaseUri, forceLoad: true);
+            // Drop the compiled user assembly so the preview boots from the stock stub, then reload this
+            // page rather than bouncing to the landing page.
+            this.JsRuntime.InvokeVoid(Try.CodeExecution.ClearUserComponentsDll);
+            NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
         }
     }
 }

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -278,8 +278,7 @@
 
         private void ClearCache()
         {
-            // Drop the compiled user assembly so the preview boots from the stock stub, then reload this
-            // page rather than bouncing to the landing page.
+            // Drop the compiled user assembly so the preview boots from the stock stub, then reload this page rather than bouncing to the landing page.
             this.JsRuntime.InvokeVoid(Try.CodeExecution.ClearUserComponentsDll);
             NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
         }


### PR DESCRIPTION
The Clear cache button did a forced navigation to `/` and nothing else. The compiled user assembly stayed in session storage, so the "cache" wasn't cleared, and you ended up on the landing page instead of where you were.

It now removes the stored assembly (the same thing the crash handler does) and force-reloads the current playground URL. Tooltip changed to "Clear compiled output and reload" to say what it does.
