### PR TITLE
Follow the OS colour scheme in the editor when no preference is stored

### DIFF
--- a/src/TryMudBlazor.Client/wwwroot/editor/main.js
+++ b/src/TryMudBlazor.Client/wwwroot/editor/main.js
@@ -146,14 +146,15 @@ window.Try.Editor = window.Try.Editor || (function () {
     return {
         create: function (id, value, language) {
             if (!id) { return; }
-            let _theme = "default";
-            let userPreferences = localStorage.getItem("userPreferences");
-            if (userPreferences) {
-                const userPreferencesJSON = JSON.parse(userPreferences);
-                if (userPreferencesJSON.hasOwnProperty("DarkTheme") && userPreferencesJSON.DarkTheme) {
-                    _theme = "vs-dark";
+            // Match the rule LayoutService applies: a stored preference wins, otherwise follow the OS.
+            let darkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            try {
+                const userPreferences = JSON.parse(localStorage.getItem("userPreferences"));
+                if (typeof userPreferences?.DarkTheme === 'boolean') {
+                    darkTheme = userPreferences.DarkTheme;
                 }
-            }
+            } catch { /* unreadable preferences fall back to the OS setting */ }
+            const _theme = darkTheme ? "vs-dark" : "default";
 
             require(['vs/editor/editor.main'], () => {
                 _editor = monaco.editor.create(document.getElementById(id), {


### PR DESCRIPTION
Bottom of the editor-and-state stack (#233), from the second-wave health review.

`main.js` only looked at `localStorage.userPreferences` when creating Monaco, so on a first visit with no stored preference the editor used `default` while `MudThemeProvider` followed the system and went dark. The editor now applies the same rule as `LayoutService`: a stored preference wins, otherwise `prefers-color-scheme`. Unreadable preferences fall back to the OS setting instead of throwing.

Verified on a Release build with a cleared profile on a dark system: Monaco starts in `vs-dark` alongside MudBlazor's dark palette. Reloading with a stored light preference still gives `default`.

Closes #130.
