### PR TITLE
Drop the unused authentication packages from the server

### DIFF
--- a/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
+++ b/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
@@ -8,8 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bottom of the server-hygiene stack (#237), from the second-wave health review. Independent of the client-side stack.

`Microsoft.AspNetCore.Authentication.JwtBearer` and `Microsoft.AspNetCore.Authentication.OpenIdConnect` are referenced by the server project but nothing in the solution uses authentication. The `NoWarn="NU1605"` on them was there to hide the package downgrade they caused. Both go, along with the warning suppression. Build and tests unchanged.
