### PR TITLE
Ignore Ctrl+S while a compile is already running

### DIFF
--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -90,6 +90,12 @@
         [JSInvokable]
         public async Task TriggerCompileAsync()
         {
+            // Ctrl+S bypasses the disabled Run button, and CompilationService is not reentrant.
+            if (this.Loading)
+            {
+                return;
+            }
+
             await this.CompileAsync();
 
             this.StateHasChanged();


### PR DESCRIPTION
Second rung of the editor-and-state stack (#233).

The Run button is disabled while a compile is in progress, but the `Ctrl+S` shortcut invokes `TriggerCompileAsync` directly and never checked. `CompilationService` keeps per-instance state (`_cachedResult`, `_lastCodeHash`) across its awaits, so two interleaved compiles could stomp on each other and the overlay text flickered between them. The shortcut is now ignored while `Loading` is true.
