### PR TITLE
Navigate with NavigationManager after saving so Clear cache returns to the snippet

### DIFF
--- a/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
+++ b/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
@@ -55,8 +55,7 @@ namespace TryMudBlazor.Client.Components
                 var snippetId = await this.SnippetsService.SaveSnippetAsync(this.CodeFiles);
                 var urlBuilder = new UriBuilder(this.NavigationManager.BaseUri) { Path = $"snippet/{snippetId}" };
                 this.SnippetLink = urlBuilder.Uri.ToString();
-                // Same page component, so this only updates the address bar and NavigationManager.Uri;
-                // a later reload (e.g. Clear cache) then comes back to the saved snippet.
+                // Same page component, so this only updates the address bar and NavigationManager.Uri; a later reload (e.g. Clear cache) then comes back to the saved snippet.
                 this.NavigationManager.NavigateTo(this.SnippetLink, replace: true);
             }
             catch (InvalidOperationException ex)

--- a/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
+++ b/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
@@ -6,10 +6,8 @@ namespace TryMudBlazor.Client.Components
     using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
-    using Microsoft.JSInterop;
     using MudBlazor;
     using Try.Core;
-    using TryMudBlazor.Client.Models;
     using TryMudBlazor.Client.Services;
 
     public partial class SaveSnippetPopup
@@ -19,9 +17,6 @@ namespace TryMudBlazor.Client.Components
 
         [Inject]
         protected IJsApiService JsApiService { get; set; }
-
-        [Inject]
-        public IJSInProcessRuntime JsRuntime { get; set; }
 
         [Inject]
         public SnippetsService SnippetsService { get; set; }
@@ -60,7 +55,9 @@ namespace TryMudBlazor.Client.Components
                 var snippetId = await this.SnippetsService.SaveSnippetAsync(this.CodeFiles);
                 var urlBuilder = new UriBuilder(this.NavigationManager.BaseUri) { Path = $"snippet/{snippetId}" };
                 this.SnippetLink = urlBuilder.Uri.ToString();
-                this.JsRuntime.InvokeVoid(Try.ChangeDisplayUrl, SnippetLink);
+                // Same page component, so this only updates the address bar and NavigationManager.Uri;
+                // a later reload (e.g. Clear cache) then comes back to the saved snippet.
+                this.NavigationManager.NavigateTo(this.SnippetLink, replace: true);
             }
             catch (InvalidOperationException ex)
             {

--- a/src/TryMudBlazor.Client/Models/TryConstants.cs
+++ b/src/TryMudBlazor.Client/Models/TryConstants.cs
@@ -3,7 +3,6 @@
     public static class Try
     {
         public const string Initialize = "Try.initialize";
-        public const string ChangeDisplayUrl = "Try.changeDisplayUrl";
         public const string Dispose = "Try.dispose";
         public static class Editor
         {

--- a/src/TryMudBlazor.Client/wwwroot/editor/main.js
+++ b/src/TryMudBlazor.Client/wwwroot/editor/main.js
@@ -104,10 +104,6 @@ window.Try = {
         })
         window.addEventListener('keydown', onKeyDown);
     },
-    changeDisplayUrl: function (url) {
-        if (!url) {return; }
-        window.history.pushState(null, null, url);
-    },
     reloadIframe: function (id, newSrc) {
         const iFrame = document.getElementById(id);
         if (!iFrame) { return; }


### PR DESCRIPTION
Third rung of the editor-and-state stack (#233).

Saving a snippet updated the address bar with `history.pushState`, which Blazor's `NavigationManager` never sees. `Clear cache` (#227) reloads `NavigationManager.Uri`, so after a save it landed on `/snippet` and dropped the id. Reproduced in the browser harness.

The popup now calls `NavigateTo(link, replace: true)`. The route resolves to the same `Repl` page type, so Blazor reuses the component instance and the editor content is untouched (verified through `Blazor.navigateTo` in the harness, since the save request itself cannot succeed without an Azure credential). A later reload returns to `/snippet/<id>`. The `changeDisplayUrl` JS helper and its constant are removed, and the popup no longer needs the JS runtime.
