### PR TITLE
Keep a theme toggle made while preferences are still loading

### DIFF
--- a/src/Try.Tests/LayoutServiceTests.cs
+++ b/src/Try.Tests/LayoutServiceTests.cs
@@ -1,0 +1,146 @@
+namespace Tests
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using TryMudBlazor.Client.Services;
+    using TryMudBlazor.Client.Services.UserPreferences;
+
+    /// <summary>
+    /// The theme toggle can be pressed while the stored preferences are still loading. These tests pause the
+    /// load with a deferred fake service, toggle, then let the load finish and check the user's choice survived.
+    /// </summary>
+    public class LayoutServiceTests
+    {
+        [Test]
+        public async Task ToggleDuringLoadWinsOverAStoredPreference()
+        {
+            var preferences = new DeferredPreferencesService();
+            var layout = new LayoutService(preferences);
+
+            var loading = layout.ApplyUserPreferences(isDarkModeDefaultTheme: false);
+            await layout.ToggleDarkMode();
+            preferences.CompleteLoad(new UserPreferences { DarkTheme = false });
+            await loading;
+
+            Assert.That(layout.IsDarkMode, Is.True);
+            Assert.That(preferences.Saved, Is.EqualTo(new[] { true }));
+        }
+
+        [Test]
+        public async Task ToggleDuringLoadWinsOverAnEmptyStore()
+        {
+            var preferences = new DeferredPreferencesService();
+            var layout = new LayoutService(preferences);
+
+            var loading = layout.ApplyUserPreferences(isDarkModeDefaultTheme: false);
+            await layout.ToggleDarkMode();
+            preferences.CompleteLoad(null);
+            await loading;
+
+            Assert.That(layout.IsDarkMode, Is.True);
+            // The toggle's save is the only one; the load must not write the default on top of it.
+            Assert.That(preferences.Saved, Is.EqualTo(new[] { true }));
+        }
+
+        [Test]
+        public async Task ToggleBeforeAnyLoadIsKeptWhenTheLoadArrivesLater()
+        {
+            var preferences = new DeferredPreferencesService();
+            var layout = new LayoutService(preferences);
+
+            await layout.ToggleDarkMode();
+            var loading = layout.ApplyUserPreferences(isDarkModeDefaultTheme: false);
+            preferences.CompleteLoad(new UserPreferences { DarkTheme = false });
+            await loading;
+
+            Assert.That(layout.IsDarkMode, Is.True);
+            Assert.That(preferences.Saved, Is.EqualTo(new[] { true }));
+        }
+
+        [Test]
+        public async Task StoredPreferenceAppliesWhenNothingWasToggled()
+        {
+            var preferences = new DeferredPreferencesService();
+            var layout = new LayoutService(preferences);
+
+            var loading = layout.ApplyUserPreferences(isDarkModeDefaultTheme: false);
+            preferences.CompleteLoad(new UserPreferences { DarkTheme = true });
+            await loading;
+
+            Assert.That(layout.IsDarkMode, Is.True);
+            Assert.That(preferences.Saved, Is.Empty);
+        }
+
+        [Test]
+        public async Task EmptyStoreSavesTheDefaultWhenNothingWasToggled()
+        {
+            var preferences = new DeferredPreferencesService();
+            var layout = new LayoutService(preferences);
+
+            var loading = layout.ApplyUserPreferences(isDarkModeDefaultTheme: true);
+            preferences.CompleteLoad(null);
+            await loading;
+
+            Assert.That(layout.IsDarkMode, Is.True);
+            Assert.That(preferences.Saved, Is.EqualTo(new[] { true }));
+        }
+
+        [Test]
+        public async Task ToggleAfterLoadFlipsTheStoredValue()
+        {
+            var preferences = new DeferredPreferencesService();
+            var layout = new LayoutService(preferences);
+
+            var loading = layout.ApplyUserPreferences(isDarkModeDefaultTheme: false);
+            preferences.CompleteLoad(new UserPreferences { DarkTheme = true });
+            await loading;
+            await layout.ToggleDarkMode();
+
+            Assert.That(layout.IsDarkMode, Is.False);
+            Assert.That(preferences.Saved, Is.EqualTo(new[] { false }));
+        }
+
+        [Test]
+        public async Task SecondLayoutSharesTheFirstLoad()
+        {
+            var preferences = new DeferredPreferencesService();
+            var layout = new LayoutService(preferences);
+
+            var first = layout.ApplyUserPreferences(isDarkModeDefaultTheme: true);
+            var second = layout.ApplyUserPreferences(isDarkModeDefaultTheme: false);
+            preferences.CompleteLoad(null);
+            await Task.WhenAll(first, second);
+
+            Assert.That(preferences.LoadCount, Is.EqualTo(1));
+            Assert.That(layout.IsDarkMode, Is.True);
+        }
+
+        /// <summary>
+        /// A preferences store whose load completes only when the test says so.
+        /// </summary>
+        private sealed class DeferredPreferencesService : IUserPreferencesService
+        {
+            private readonly TaskCompletionSource<UserPreferences> _load = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public int LoadCount { get; private set; }
+
+            /// <summary>The DarkTheme value of every save, in order.</summary>
+            public List<bool> Saved { get; } = [];
+
+            public void CompleteLoad(UserPreferences stored) => _load.SetResult(stored);
+
+            public Task<UserPreferences> LoadUserPreferences()
+            {
+                LoadCount++;
+                return _load.Task;
+            }
+
+            public Task SaveUserPreferences(UserPreferences userPreferences)
+            {
+                Saved.Add(userPreferences.DarkTheme);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/TryMudBlazor.Client/Services/LayoutService.cs
+++ b/src/TryMudBlazor.Client/Services/LayoutService.cs
@@ -1,4 +1,4 @@
-﻿namespace TryMudBlazor.Client.Services;
+namespace TryMudBlazor.Client.Services;
 
 using System;
 using System.Threading.Tasks;
@@ -8,6 +8,7 @@ public class LayoutService
 {
     private readonly IUserPreferencesService _userPreferencesService;
     private UserPreferences.UserPreferences _userPreferences;
+    private Task _initialization;
 
     public bool IsDarkMode { get; private set; } = false;
 
@@ -21,12 +22,30 @@ public class LayoutService
         IsDarkMode = value;
     }
 
-    public async Task ApplyUserPreferences(bool isDarkModeDefaultTheme)
+    /// <summary>
+    /// Loads the stored preferences once per app lifetime. Every layout awaits the same load, and a load that
+    /// finishes after the user has already toggled the theme leaves that choice alone (see <see cref="ToggleDarkMode"/>).
+    /// </summary>
+    public Task ApplyUserPreferences(bool isDarkModeDefaultTheme)
     {
-        _userPreferences = await _userPreferencesService.LoadUserPreferences();
+        return _initialization ??= LoadUserPreferencesAsync(isDarkModeDefaultTheme);
+    }
+
+    private async Task LoadUserPreferencesAsync(bool isDarkModeDefaultTheme)
+    {
+        var storedPreferences = await _userPreferencesService.LoadUserPreferences();
+
         if (_userPreferences != null)
         {
-            IsDarkMode = _userPreferences.DarkTheme;
+            // The user toggled the theme while the load was in flight. That choice is newer than anything
+            // in storage, and ToggleDarkMode has already saved it, so the older value must not replace it.
+            return;
+        }
+
+        if (storedPreferences != null)
+        {
+            _userPreferences = storedPreferences;
+            IsDarkMode = storedPreferences.DarkTheme;
         }
         else
         {
@@ -40,9 +59,14 @@ public class LayoutService
 
     private void OnMajorUpdateOccured() => MajorUpdateOccured?.Invoke(this, EventArgs.Empty);
 
+    /// <summary>
+    /// Flips the theme relative to what the user currently sees and persists it. Works before, during and after
+    /// the initial load; a load still in flight will not overwrite the result.
+    /// </summary>
     public async Task ToggleDarkMode()
     {
         IsDarkMode = !IsDarkMode;
+        _userPreferences ??= new UserPreferences.UserPreferences();
         _userPreferences.DarkTheme = IsDarkMode;
         await _userPreferencesService.SaveUserPreferences(_userPreferences);
         OnMajorUpdateOccured();


### PR DESCRIPTION
`ToggleDarkMode` dereferences `_userPreferences`, which `ApplyUserPreferences` only assigns after it has awaited the stored value. Clicking the toggle in that window throws.

A null check alone isn't enough: the load can still finish after the toggle and put the older stored value back, or save the default over the top of what the user just picked.

The load now runs once, behind a single task that both layouts await, and it backs off if a toggle has already happened. The toggle applies straight away to whatever the user is looking at and saves; when the load completes later it sees the choice is already made and does nothing.

Tests use a fake `IUserPreferencesService` whose load only completes when told to, so the interleaving is deterministic. Covered for a stored preference and for an empty store, plus the normal non-racing paths.
