### PR TITLE
Create the snippet blob client once at startup instead of per request

### DIFF
--- a/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
+++ b/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
@@ -1,6 +1,4 @@
 using Azure;
-using Azure.Identity;
-using Azure.Storage;
 using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Mvc;
 using TryMudBlazor.Server.Utilities;
@@ -14,34 +12,9 @@ public class SnippetsController : ControllerBase
 {
     private readonly BlobContainerClient _containerClient;
 
-    public SnippetsController(IConfiguration config)
+    public SnippetsController(BlobContainerClient containerClient)
     {
-        var snippetsContainerUrl = config["SnippetsContainerUrl"];
-        var accessKey = config["SnippetsAccessKey"];
-
-        if (string.IsNullOrEmpty(snippetsContainerUrl) || string.IsNullOrEmpty(accessKey))
-        {
-            throw new Exception("Please configure SnippetsContainerUrl and SnippetsAccessKey in appsettings.json");
-        }
-
-        var containerUri = new Uri(snippetsContainerUrl);
-
-        if (accessKey == "secret")
-        {
-            var defaultAzureCredentialOptions = new DefaultAzureCredentialOptions
-            {
-                ManagedIdentityClientId = config["ManagedCredentialsId"]
-            };
-            _containerClient = new BlobContainerClient(containerUri,
-                new DefaultAzureCredential(defaultAzureCredentialOptions));
-        }
-        else
-        {
-            var blobUri = new BlobUriBuilder(containerUri);
-            var accountName = blobUri.AccountName;
-            var key = new StorageSharedKeyCredential(accountName, accessKey);
-            _containerClient = new BlobContainerClient(containerUri, key);
-        }
+        _containerClient = containerClient;
     }
 
     [HttpGet("{snippetId}")]

--- a/src/TryMudBlazor.Server/Program.cs
+++ b/src/TryMudBlazor.Server/Program.cs
@@ -1,4 +1,5 @@
 using MudBlazor.Examples.Data;
+using TryMudBlazor.Server.Utilities;
 
 namespace TryMudBlazor.Server;
 
@@ -8,6 +9,8 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
         builder.Services.AddScoped<IPeriodicTableService, PeriodicTableService>();
+        // Built eagerly so a missing snippet configuration fails at startup rather than on the first save.
+        builder.Services.AddSingleton(SnippetStorage.CreateContainerClient(builder.Configuration));
         builder.Services.AddCors(options =>
         {
             options.AddDefaultPolicy(policy =>

--- a/src/TryMudBlazor.Server/Program.cs
+++ b/src/TryMudBlazor.Server/Program.cs
@@ -9,7 +9,6 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
         builder.Services.AddScoped<IPeriodicTableService, PeriodicTableService>();
-        // Built eagerly so a missing snippet configuration fails at startup rather than on the first save.
         builder.Services.AddSingleton(SnippetStorage.CreateContainerClient(builder.Configuration));
         builder.Services.AddCors(options =>
         {

--- a/src/TryMudBlazor.Server/Utilities/SnippetStorage.cs
+++ b/src/TryMudBlazor.Server/Utilities/SnippetStorage.cs
@@ -1,0 +1,37 @@
+using Azure.Identity;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+
+namespace TryMudBlazor.Server.Utilities;
+
+public static class SnippetStorage
+{
+    /// <summary>
+    /// Builds the container client once at startup. Creating it per request would also create a new
+    /// <see cref="DefaultAzureCredential"/> each time, and with it a fresh token acquisition on every save or load.
+    /// </summary>
+    public static BlobContainerClient CreateContainerClient(IConfiguration config)
+    {
+        var snippetsContainerUrl = config["SnippetsContainerUrl"];
+        var accessKey = config["SnippetsAccessKey"];
+
+        if (string.IsNullOrEmpty(snippetsContainerUrl) || string.IsNullOrEmpty(accessKey))
+        {
+            throw new InvalidOperationException("Please configure SnippetsContainerUrl and SnippetsAccessKey in appsettings.json");
+        }
+
+        var containerUri = new Uri(snippetsContainerUrl);
+
+        if (accessKey == "secret")
+        {
+            var defaultAzureCredentialOptions = new DefaultAzureCredentialOptions
+            {
+                ManagedIdentityClientId = config["ManagedCredentialsId"]
+            };
+            return new BlobContainerClient(containerUri, new DefaultAzureCredential(defaultAzureCredentialOptions));
+        }
+
+        var accountName = new BlobUriBuilder(containerUri).AccountName;
+        return new BlobContainerClient(containerUri, new StorageSharedKeyCredential(accountName, accessKey));
+    }
+}

--- a/src/TryMudBlazor.Server/Utilities/SnippetStorage.cs
+++ b/src/TryMudBlazor.Server/Utilities/SnippetStorage.cs
@@ -7,8 +7,7 @@ namespace TryMudBlazor.Server.Utilities;
 public static class SnippetStorage
 {
     /// <summary>
-    /// Builds the container client once at startup. Creating it per request would also create a new
-    /// <see cref="DefaultAzureCredential"/> each time, and with it a fresh token acquisition on every save or load.
+    /// Builds the container client once at startup. Creating it per request would also create a new <see cref="DefaultAzureCredential"/> each time, and with it a fresh token acquisition on every save or load.
     /// </summary>
     public static BlobContainerClient CreateContainerClient(IConfiguration config)
     {


### PR DESCRIPTION
Second rung of the server-hygiene stack (#237).

`SnippetsController` built a `BlobContainerClient`, and with it a new `DefaultAzureCredential`, in its constructor. Controllers are transient, so every save and load created a fresh credential and acquired a token again instead of reusing the cached one.

The client is now created once at startup by `SnippetStorage.CreateContainerClient` and injected into the controller. Building it eagerly also means a missing `SnippetsContainerUrl` or `SnippetsAccessKey` fails at boot instead of on the first save. The credential selection (shared key vs. managed identity via `"secret"`) is unchanged.

Verified that the Release build starts and serves the playground with the eager registration. The Azure upload path itself is not testable locally.
