### PR TITLE
Allocate snippet IDs without lockstep retries and bound the failure modes

### DIFF
--- a/src/Try.Tests/SnippetsControllerTests.cs
+++ b/src/Try.Tests/SnippetsControllerTests.cs
@@ -1,0 +1,206 @@
+#nullable enable
+
+namespace Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using NUnit.Framework;
+    using Try.Core;
+    using TryMudBlazor.Server.Controllers;
+    using TryMudBlazor.Server.Utilities;
+    using static TryMudBlazor.Server.Utilities.SnippetsEncoder;
+
+    /// <summary>
+    /// Drives the controller against an in-memory store and a frozen clock, so ID collisions, exhaustion,
+    /// cancellation and concurrent saves are all deterministic.
+    /// </summary>
+    public class SnippetsControllerTests
+    {
+        // 12:00:00.123 UTC is 43,200,123 ms into the day.
+        private static readonly DateTimeOffset Noon = new(2026, 9, 5, 12, 0, 0, 123, TimeSpan.Zero);
+        private const string TimestampId = "2026090543200123";
+        private const string TimestampPath = "2026/09/05/43200123";
+
+        private static readonly byte[] ValidArchive = SnippetsServiceTests.Zip(
+        [
+            new CodeFile { Path = "__Main.razor", Content = "<MudText>hello</MudText>" },
+        ]);
+
+        [Test]
+        public async Task FirstAttemptStoresUnderTheTimestampId()
+        {
+            var store = new FakeSnippetStore();
+
+            var result = await CreateController(store).Post();
+
+            Assert.That(DecodeSnippetId(SnippetIdOf(result)), Is.EqualTo(TimestampId));
+            Assert.That(store.Paths, Is.EqualTo(new[] { TimestampPath }));
+        }
+
+        [Test]
+        public async Task OneConflictRetriesWithADifferentId()
+        {
+            var store = new FakeSnippetStore { RejectFirst = 1 };
+
+            var result = await CreateController(store).Post();
+
+            Assert.That(store.Attempts, Has.Count.EqualTo(2));
+            Assert.That(store.Attempts[0], Is.EqualTo(TimestampPath));
+            Assert.That(store.Attempts[1], Is.Not.EqualTo(TimestampPath));
+            Assert.That(DecodeSnippetId(SnippetIdOf(result)), Does.StartWith("20260905").And.Length.EqualTo(SnippetIdLength));
+            Assert.That(store.Paths, Is.EqualTo(new[] { store.Attempts[1] }));
+        }
+
+        [Test]
+        public async Task SeveralConflictsStillSucceedWithinTheBudget()
+        {
+            var store = new FakeSnippetStore { RejectFirst = SnippetsController.MaxSaveAttempts - 1 };
+
+            var result = await CreateController(store).Post();
+
+            Assert.That(result, Is.InstanceOf<OkObjectResult>());
+            Assert.That(store.Attempts, Has.Count.EqualTo(SnippetsController.MaxSaveAttempts));
+            Assert.That(store.Attempts.Distinct().Count(), Is.EqualTo(store.Attempts.Count), "retries must not repeat a candidate");
+        }
+
+        [Test]
+        public async Task ExhaustedBudgetIsAServiceUnavailableNotAServerError()
+        {
+            var store = new FakeSnippetStore { RejectFirst = int.MaxValue };
+            var controller = CreateController(store);
+
+            var result = await controller.Post();
+
+            var problem = (ObjectResult)result;
+            Assert.That(problem.StatusCode, Is.EqualTo(StatusCodes.Status503ServiceUnavailable));
+            Assert.That(controller.Response.Headers.RetryAfter.ToString(), Is.EqualTo("1"));
+            Assert.That(store.Attempts, Has.Count.EqualTo(SnippetsController.MaxSaveAttempts));
+            Assert.That(store.Paths, Is.Empty);
+        }
+
+        [Test]
+        public void CancelledRequestNeverReachesStorage()
+        {
+            var store = new FakeSnippetStore();
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(() => CreateController(store, cancellation.Token).Post());
+            Assert.That(store.Attempts, Is.Empty);
+        }
+
+        [Test]
+        public void CancellationDuringUploadStopsTheRetries()
+        {
+            using var cancellation = new CancellationTokenSource();
+            var store = new FakeSnippetStore { RejectFirst = int.MaxValue, OnUpload = cancellation.Cancel };
+
+            Assert.CatchAsync<OperationCanceledException>(() => CreateController(store, cancellation.Token).Post());
+            Assert.That(store.Attempts, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task ConcurrentSavesInTheSameMillisecondAllGetDistinctIds()
+        {
+            const int contenders = 25;
+            var store = new FakeSnippetStore();
+
+            var results = await Task.WhenAll(Enumerable.Range(0, contenders)
+                .Select(seed => Task.Run(() => CreateController(store, seed: seed).Post())));
+
+            var ids = results.Select(SnippetIdOf).Select(DecodeSnippetId).ToList();
+            Assert.That(ids, Has.Count.EqualTo(contenders));
+            Assert.That(ids.Distinct().Count(), Is.EqualTo(contenders));
+            Assert.That(ids, Has.Exactly(1).EqualTo(TimestampId), "only one request can own the timestamp ID");
+            Assert.That(store.Paths, Has.Count.EqualTo(contenders));
+        }
+
+        [Test]
+        public async Task GetReturnsTheStoredArchive()
+        {
+            var store = new FakeSnippetStore();
+            await CreateController(store).Post();
+
+            var result = await CreateController(store).Get(EncodeSnippetId(TimestampId));
+
+            var file = (FileStreamResult)result;
+            using var downloaded = new MemoryStream();
+            await file.FileStream.CopyToAsync(downloaded);
+            Assert.That(downloaded.ToArray(), Is.EqualTo(ValidArchive));
+        }
+
+        [Test]
+        public async Task GetReturnsNotFoundForAMissingSnippet()
+        {
+            var result = await CreateController(new FakeSnippetStore()).Get(EncodeSnippetId(TimestampId));
+
+            Assert.That(result, Is.InstanceOf<NotFoundResult>());
+        }
+
+        private static string SnippetIdOf(IActionResult result) => (string)((OkObjectResult)result).Value!;
+
+        private static SnippetsController CreateController(ISnippetStore store, CancellationToken cancellationToken = default, int seed = 1)
+        {
+            var httpContext = new DefaultHttpContext { RequestAborted = cancellationToken };
+            httpContext.Request.Body = new MemoryStream(ValidArchive);
+
+            // A Random per controller: Random.Shared is thread-safe but a seeded instance is not.
+            var allocator = new SnippetIdAllocator(new FrozenClock(Noon), new Random(seed));
+            return new SnippetsController(store, allocator)
+            {
+                ControllerContext = new ControllerContext { HttpContext = httpContext },
+            };
+        }
+
+        private sealed class FrozenClock(DateTimeOffset now) : TimeProvider
+        {
+            public override DateTimeOffset GetUtcNow() => now;
+        }
+
+        private sealed class FakeSnippetStore : ISnippetStore
+        {
+            private readonly ConcurrentDictionary<string, byte[]> _blobs = new();
+            private readonly ConcurrentQueue<string> _attempts = new();
+            private int _uploads;
+
+            /// <summary>How many uploads to answer with "already exists" before behaving normally.</summary>
+            public int RejectFirst { get; init; }
+
+            /// <summary>Runs on every upload after the attempt is recorded and before the cancellation token is checked.</summary>
+            public Action? OnUpload { get; init; }
+
+            public IReadOnlyList<string> Attempts => _attempts.ToArray();
+
+            public IReadOnlyCollection<string> Paths => _blobs.Keys.ToArray();
+
+            public Task<Stream?> DownloadAsync(string blobPath, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult<Stream?>(_blobs.TryGetValue(blobPath, out var bytes) ? new MemoryStream(bytes) : null);
+            }
+
+            public Task<bool> TryUploadAsync(string blobPath, Stream content, CancellationToken cancellationToken)
+            {
+                _attempts.Enqueue(blobPath);
+                OnUpload?.Invoke();
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (Interlocked.Increment(ref _uploads) <= RejectFirst)
+                {
+                    return Task.FromResult(false);
+                }
+
+                using var buffer = new MemoryStream();
+                content.CopyTo(buffer);
+                return Task.FromResult(_blobs.TryAdd(blobPath, buffer.ToArray()));
+            }
+        }
+    }
+}

--- a/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
+++ b/src/TryMudBlazor.Server/Controllers/SnippetsController.cs
@@ -1,5 +1,3 @@
-using Azure;
-using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Mvc;
 using TryMudBlazor.Server.Utilities;
 using static TryMudBlazor.Server.Utilities.SnippetsEncoder;
@@ -10,11 +8,19 @@ namespace TryMudBlazor.Server.Controllers;
 [ApiController]
 public class SnippetsController : ControllerBase
 {
-    private readonly BlobContainerClient _containerClient;
+    /// <summary>
+    /// After the timestamp candidate every retry is random within a space of 10^8 per day, so a few attempts
+    /// are plenty, and the budget keeps the storage work one anonymous request can cause bounded.
+    /// </summary>
+    public const int MaxSaveAttempts = 5;
 
-    public SnippetsController(BlobContainerClient containerClient)
+    private readonly ISnippetStore _store;
+    private readonly SnippetIdAllocator _idAllocator;
+
+    public SnippetsController(ISnippetStore store, SnippetIdAllocator idAllocator)
     {
-        _containerClient = containerClient;
+        _store = store;
+        _idAllocator = idAllocator;
     }
 
     [HttpGet("{snippetId}")]
@@ -30,30 +36,24 @@ public class SnippetsController : ControllerBase
             return Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Invalid snippet ID.");
         }
 
-        var blob = _containerClient.GetBlobClient(BlobPath(decodedSnippetId));
-        var zipStream = new MemoryStream();
-        try
-        {
-            var response = await blob.DownloadAsync();
-            await response.Value.Content.CopyToAsync(zipStream);
-        }
-        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        var archive = await _store.DownloadAsync(BlobPath(decodedSnippetId), HttpContext.RequestAborted);
+        if (archive is null)
         {
             return NotFound();
         }
 
-        zipStream.Position = 0;
-
-        return File(zipStream, "application/octet-stream", "snippet.zip");
+        return File(archive, "application/octet-stream", "snippet.zip");
     }
 
     [HttpPost]
     [RequestSizeLimit(SnippetArchiveValidator.MaxArchiveBytes)]
     public async Task<IActionResult> Post()
     {
+        var cancellationToken = HttpContext.RequestAborted;
+
         // Buffer the upload so it can be validated before anything reaches storage.
         var archiveStream = new MemoryStream();
-        await Request.Body.CopyToAsync(archiveStream);
+        await Request.Body.CopyToAsync(archiveStream, cancellationToken);
         archiveStream.Position = 0;
 
         var validationError = SnippetArchiveValidator.Validate(archiveStream);
@@ -62,23 +62,20 @@ public class SnippetsController : ControllerBase
             return Problem(statusCode: StatusCodes.Status400BadRequest, detail: validationError);
         }
 
-        archiveStream.Position = 0;
+        for (var attempt = 1; attempt <= MaxSaveAttempts; attempt++)
+        {
+            archiveStream.Position = 0;
+            var snippetId = _idAllocator.NextCandidate(attempt);
+            if (await _store.TryUploadAsync(BlobPath(snippetId), archiveStream, cancellationToken))
+            {
+                return Ok(EncodeSnippetId(snippetId));
+            }
+        }
 
-        var newSnippetId = NewSnippetId();
-        await _containerClient.UploadBlobAsync(BlobPath(newSnippetId), archiveStream);
-
-        return Ok(EncodeSnippetId(newSnippetId));
-    }
-
-    private static string NewSnippetId()
-    {
-        var yearFolder = DateTime.Now.Year;
-        var monthFolder = DateTime.Now.Month;
-        var dayFolder = DateTime.Now.Day;
-        var time = Convert.ToInt32(DateTime.Now.TimeOfDay.TotalMilliseconds);
-        var snippetTime = $"{time:D8}";
-
-        return $"{yearFolder:0000}{monthFolder:00}{dayFolder:00}{snippetTime:D8}";
+        // Storage answered every time; we just did not find a free ID within budget. That is a retry for the
+        // client, not a server fault, so say so instead of letting a storage exception become a 500.
+        Response.Headers.RetryAfter = "1";
+        return Problem(statusCode: StatusCodes.Status503ServiceUnavailable, detail: "Could not allocate an ID for the snippet. Please try again.");
     }
 
     private static string BlobPath(string snippetId)

--- a/src/TryMudBlazor.Server/Program.cs
+++ b/src/TryMudBlazor.Server/Program.cs
@@ -9,7 +9,10 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
         builder.Services.AddScoped<IPeriodicTableService, PeriodicTableService>();
-        builder.Services.AddSingleton(SnippetStorage.CreateContainerClient(builder.Configuration));
+        builder.Services.AddSingleton<ISnippetStore>(new BlobSnippetStore(SnippetStorage.CreateContainerClient(builder.Configuration)));
+        builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddSingleton(Random.Shared);
+        builder.Services.AddSingleton<SnippetIdAllocator>();
         builder.Services.AddCors(options =>
         {
             options.AddDefaultPolicy(policy =>

--- a/src/TryMudBlazor.Server/Utilities/BlobSnippetStore.cs
+++ b/src/TryMudBlazor.Server/Utilities/BlobSnippetStore.cs
@@ -1,0 +1,45 @@
+using Azure;
+using Azure.Storage.Blobs;
+
+namespace TryMudBlazor.Server.Utilities;
+
+public sealed class BlobSnippetStore : ISnippetStore
+{
+    private readonly BlobContainerClient _containerClient;
+
+    public BlobSnippetStore(BlobContainerClient containerClient)
+    {
+        _containerClient = containerClient;
+    }
+
+    public async Task<Stream?> DownloadAsync(string blobPath, CancellationToken cancellationToken)
+    {
+        var archive = new MemoryStream();
+        try
+        {
+            var response = await _containerClient.GetBlobClient(blobPath).DownloadAsync(cancellationToken);
+            await response.Value.Content.CopyToAsync(archive, cancellationToken);
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status404NotFound)
+        {
+            return null;
+        }
+
+        archive.Position = 0;
+        return archive;
+    }
+
+    public async Task<bool> TryUploadAsync(string blobPath, Stream content, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // UploadBlobAsync never overwrites, so an existing blob comes back as a 409 rather than being replaced.
+            await _containerClient.UploadBlobAsync(blobPath, content, cancellationToken);
+            return true;
+        }
+        catch (RequestFailedException exception) when (exception.Status == StatusCodes.Status409Conflict)
+        {
+            return false;
+        }
+    }
+}

--- a/src/TryMudBlazor.Server/Utilities/ISnippetStore.cs
+++ b/src/TryMudBlazor.Server/Utilities/ISnippetStore.cs
@@ -1,0 +1,18 @@
+namespace TryMudBlazor.Server.Utilities;
+
+/// <summary>
+/// Where snippet archives live, addressed by the blob path SnippetsController derives from the storage ID.
+/// </summary>
+public interface ISnippetStore
+{
+    /// <summary>
+    /// Returns the archive stored at <paramref name="blobPath"/>, or null when there is none.
+    /// </summary>
+    Task<Stream?> DownloadAsync(string blobPath, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Stores the archive unless something already exists at <paramref name="blobPath"/>, in which case
+    /// nothing is written and false is returned.
+    /// </summary>
+    Task<bool> TryUploadAsync(string blobPath, Stream content, CancellationToken cancellationToken);
+}

--- a/src/TryMudBlazor.Server/Utilities/SnippetIdAllocator.cs
+++ b/src/TryMudBlazor.Server/Utilities/SnippetIdAllocator.cs
@@ -1,0 +1,35 @@
+namespace TryMudBlazor.Server.Utilities;
+
+/// <summary>
+/// Produces candidate storage IDs: sixteen digits, the UTC date as yyyyMMdd followed by an eight-digit suffix
+/// that only has to be unique within that day. The format is what <see cref="SnippetsEncoder"/> encodes and
+/// what existing links decode to, so it must not change.
+/// </summary>
+public sealed class SnippetIdAllocator
+{
+    private const int SuffixSpace = 100_000_000;
+
+    private readonly TimeProvider _timeProvider;
+    private readonly Random _random;
+
+    public SnippetIdAllocator(TimeProvider timeProvider, Random random)
+    {
+        _timeProvider = timeProvider;
+        _random = random;
+    }
+
+    /// <summary>
+    /// The first candidate is the millisecond of the day, so IDs keep sorting by time in storage. If that one is
+    /// already taken, every later candidate is drawn at random from the day's space: requests that collided on
+    /// the timestamp then pick independent IDs instead of retrying the same next value in lockstep.
+    /// </summary>
+    public string NextCandidate(int attempt)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var suffix = attempt <= 1
+            ? (int)now.TimeOfDay.TotalMilliseconds
+            : _random.Next(SuffixSpace);
+
+        return $"{now:yyyyMMdd}{suffix:D8}";
+    }
+}


### PR DESCRIPTION
The storage ID is `yyyyMMdd` plus an 8-digit suffix, and the suffix was the local millisecond of the day. Two saves in the same millisecond map to the same blob, `UploadBlobAsync` throws 409, and the user gets a 500. Retrying on the clock alone doesn't help because every request that collided picks the same next value again.

The first candidate is still the timestamp so blobs keep sorting by time, but any retry uses a random suffix from the day's 10^8 space, so colliding requests go their separate ways on the second attempt. Date is UTC now. Encoding, ID length and blob paths are unchanged, existing links still work.

Storage access goes through a small `ISnippetStore` so the controller can be tested without Azure. The blob implementation maps 404 to null and 409 to false, and `RequestAborted` is passed through the body copy, the upload and the download. If all five attempts collide the response is a 503 with `Retry-After: 1` rather than an unhandled storage exception; the client already shows "try again later" for that.

No delay between attempts. With random candidates there's nothing to desynchronise, and it keeps one anonymous request to at most five storage calls.

Tests run the controller against an in-memory store, a frozen `TimeProvider` and a seeded `Random`: success, one and several 409s, exhaustion, cancellation before and during upload, 25 concurrent saves in the same millisecond, and both `Get` outcomes.
