### PR TITLE
Parse the periodic table once and simplify the snippet ID encoder

### DIFF
--- a/src/MudBlazor.Examples.Data/Models/Element.cs
+++ b/src/MudBlazor.Examples.Data/Models/Element.cs
@@ -1,18 +1,23 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 
 namespace MudBlazor.Examples.Data.Models
 {
+    /// <summary>
+    /// A row of the periodic table. Values are set once when the table is deserialised and never change, which
+    /// lets PeriodicTableService hand the same instances to every request.
+    /// </summary>
     public class Element
     {
-        public string Group { get; set; }
-        public int Position { get; set; }
-        public string Name { get; set; }
-        public int Number { get; set; }
+        public string Group { get; init; }
+        public int Position { get; init; }
+        public string Name { get; init; }
+        public int Number { get; init; }
 
         [JsonPropertyName("small")]
-        public string Sign { get; set; }
-        public double Molar { get; set; }
-        public IList<int> Electrons { get; set; }
+        public string Sign { get; init; }
+        public double Molar { get; init; }
+        public ImmutableArray<int> Electrons { get; init; }
 
         /// <summary>
         /// Overriding Equals is essential for use with Select and Table because they use HashSets internally

--- a/src/MudBlazor.Examples.Data/PeriodicTableService.cs
+++ b/src/MudBlazor.Examples.Data/PeriodicTableService.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Collections.Immutable;
+using System.Reflection;
 using System.Text.Json;
 using MudBlazor.Examples.Data.Models;
 
@@ -6,31 +7,39 @@ namespace MudBlazor.Examples.Data
 {
     public class PeriodicTableService : IPeriodicTableService
     {
-        public async Task<IEnumerable<Element>> GetElements()
+        // The table is an embedded resource that never changes, so parse it once for the lifetime of the process.
+        // Every caller gets the same immutable array of immutable elements, so nothing a consumer does to a
+        // result can leak into the next request.
+        private static readonly Lazy<ImmutableArray<Element>> Elements = new(LoadElements);
+
+        public Task<IEnumerable<Element>> GetElements()
         {
-            return await GetElements(string.Empty);
+            return GetElements(string.Empty);
         }
 
-        public async Task<IEnumerable<Element>> GetElements(string search = "")
+        public Task<IEnumerable<Element>> GetElements(string search = "")
         {
-            var elements = new List<Element>();
-            var key = GetResourceKey(typeof(PeriodicTableService).Assembly, "Elements.json");
-            using var stream = typeof(PeriodicTableService).Assembly.GetManifestResourceStream(key);
-            var table = await JsonSerializer.DeserializeAsync<Table>(stream, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
-            foreach (var elementGroup in table.ElementGroups)
+            IEnumerable<Element> elements = Elements.Value;
+            if (!string.IsNullOrEmpty(search))
             {
-                elements = elements.Concat(elementGroup.Elements).ToList();
+                elements = elements.Where(elm => (elm.Sign + elm.Name).Contains(search, StringComparison.InvariantCultureIgnoreCase));
             }
 
-            if (search == string.Empty)
-                return elements;
-            else
-                return elements.Where(elm => (elm.Sign + elm.Name).Contains(search, StringComparison.InvariantCultureIgnoreCase));
+            return Task.FromResult(elements);
         }
 
         public static string GetResourceKey(Assembly assembly, string embeddedFile)
         {
             return assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(embeddedFile));
+        }
+
+        private static ImmutableArray<Element> LoadElements()
+        {
+            var assembly = typeof(PeriodicTableService).Assembly;
+            using var stream = assembly.GetManifestResourceStream(GetResourceKey(assembly, "Elements.json"));
+            var table = JsonSerializer.Deserialize<Table>(stream, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return table.ElementGroups.SelectMany(elementGroup => elementGroup.Elements).ToImmutableArray();
         }
     }
 }

--- a/src/Try.Tests/PeriodicTableServiceTests.cs
+++ b/src/Try.Tests/PeriodicTableServiceTests.cs
@@ -1,0 +1,71 @@
+namespace Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using MudBlazor.Examples.Data;
+    using MudBlazor.Examples.Data.Models;
+    using NUnit.Framework;
+
+    public class PeriodicTableServiceTests
+    {
+        [Test]
+        public async Task TheTableIsParsedOnceAndSharedBetweenCalls()
+        {
+            var first = (await new PeriodicTableService().GetElements()).ToList();
+            var second = (await new PeriodicTableService().GetElements()).ToList();
+
+            Assert.That(first, Is.Not.Empty);
+            Assert.That(second, Has.Count.EqualTo(first.Count));
+            Assert.That(first.Zip(second).All(pair => ReferenceEquals(pair.First, pair.Second)), Is.True, "a second call must reuse the parsed elements");
+        }
+
+        [TestCase("")]
+        [TestCase("he")]
+        [TestCase("GOLD")]
+        [TestCase("Au")]
+        [TestCase("no such element")]
+        public async Task SearchMatchesTheOriginalSignPlusNameRule(string search)
+        {
+            var service = new PeriodicTableService();
+            var all = (await service.GetElements()).ToList();
+            var expected = all.Where(elm => (elm.Sign + elm.Name).Contains(search, StringComparison.InvariantCultureIgnoreCase)).ToList();
+
+            var actual = (await service.GetElements(search)).ToList();
+
+            Assert.That(actual, Is.EqualTo(expected));
+            if (search == "he")
+            {
+                Assert.That(actual.Select(e => e.Name), Does.Contain("Helium"));
+            }
+        }
+
+        [Test]
+        public async Task ConcurrentReadersSeeTheSameTable()
+        {
+            var reads = await Task.WhenAll(Enumerable.Range(0, 50)
+                .Select(_ => Task.Run(async () => (await new PeriodicTableService().GetElements()).ToList())));
+
+            Assert.That(reads[0], Is.Not.Empty);
+            Assert.That(reads.Select(r => r.Count), Has.All.EqualTo(reads[0].Count));
+            Assert.That(reads.Select(r => r[0]).Distinct().Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task ResultsCannotBeUsedToChangeTheSharedTable()
+        {
+            var elements = await new PeriodicTableService().GetElements();
+
+            Assert.That(elements, Is.Not.InstanceOf<List<Element>>());
+            Assert.Throws<NotSupportedException>(() => ((IList<Element>)elements).Add(new Element { Name = "Unobtainium" }));
+            Assert.Throws<NotSupportedException>(() => ((IList<Element>)elements).Clear());
+
+            var hydrogen = elements.First();
+            Assert.That(hydrogen.Electrons, Is.InstanceOf<ImmutableArray<int>>());
+            Assert.That(typeof(Element).GetProperties().Select(p => p.SetMethod).Where(m => m is not null)
+                .All(m => m.ReturnParameter.GetRequiredCustomModifiers().Any(t => t.Name == "IsExternalInit")), Is.True, "every Element property must be init-only");
+        }
+    }
+}

--- a/src/TryMudBlazor.Server/Utilities/SnippetIdEncoder.cs
+++ b/src/TryMudBlazor.Server/Utilities/SnippetIdEncoder.cs
@@ -58,19 +58,21 @@ public static class SnippetsEncoder
         ['Z'] = '9',
     };
 
+    // Index 0-9: every letter that stands for that digit.
+    private static readonly string[] LettersForDigit = Enumerable.Range(0, 10)
+        .Select(digit => new string(LetterToDigitIdMappings.Where(kv => kv.Value == (char)('0' + digit)).Select(kv => kv.Key).ToArray()))
+        .ToArray();
+
     public static string EncodeSnippetId(string snippetId)
     {
-        var encoded = string.Empty;
-
-        foreach (var digit in snippetId)
+        return string.Create(snippetId.Length, snippetId, static (encoded, digits) =>
         {
-            var choiceOfLetters = LetterToDigitIdMappings.Where(kv => kv.Value == digit).ToArray();
-            var letter = choiceOfLetters.Skip(Random.Shared.Next(choiceOfLetters.Length)).First();
-
-            encoded += letter.Key;
-        }
-
-        return encoded;
+            for (var i = 0; i < digits.Length; i++)
+            {
+                var letters = LettersForDigit[digits[i] - '0'];
+                encoded[i] = letters[Random.Shared.Next(letters.Length)];
+            }
+        });
     }
 
     public const int SnippetIdLength = 16;
@@ -86,18 +88,15 @@ public static class SnippetsEncoder
             throw new InvalidDataException("Invalid snippet ID");
         }
 
-        var decoded = string.Empty;
-
-        foreach (var letter in encoded)
+        var decoded = new char[SnippetIdLength];
+        for (var i = 0; i < encoded.Length; i++)
         {
-            if (!LetterToDigitIdMappings.TryGetValue(letter, out var digit))
+            if (!LetterToDigitIdMappings.TryGetValue(encoded[i], out decoded[i]))
             {
                 throw new InvalidDataException("Invalid snippet ID");
             }
-
-            decoded += digit;
         }
 
-        return decoded;
+        return new string(decoded);
     }
 }


### PR DESCRIPTION
`PeriodicTableService` deserialised `Elements.json` from the embedded resource on every request. It's parsed once now.

Since the same instances are handed to every caller, the cache is an `ImmutableArray<Element>` and `Element` is init-only (electrons as `ImmutableArray<int>`), so nothing a consumer does to a result can leak into the next request. Tests check it's parsed once, that search gives the same results as the old `Sign + Name` contains check, concurrent reads, and that the results can't be mutated.

Also swaps the per-character LINQ scan and string concatenation in `SnippetsEncoder` for a lookup table. Same output, existing round-trip tests unchanged.
